### PR TITLE
Skip all these IPv6

### DIFF
--- a/src/Resolver.cpp
+++ b/src/Resolver.cpp
@@ -26,6 +26,7 @@ dunedaq::utilities::get_ips_from_hostname(std::string hostname)
 
   for (auto rp = result; rp != nullptr; rp = rp->ai_next) {
     char hbuf[NI_MAXHOST], sbuf[NI_MAXSERV];
+    if (rp->ai_family == AF_INET6) continue;
     getnameinfo(rp->ai_addr, rp->ai_addrlen, hbuf, sizeof(hbuf), sbuf, sizeof(sbuf), NI_NUMERICHOST | NI_NUMERICSERV);
     auto result = std::string(hbuf);
     bool duplicate = false;

--- a/src/Resolver.cpp
+++ b/src/Resolver.cpp
@@ -26,7 +26,10 @@ dunedaq::utilities::get_ips_from_hostname(std::string hostname)
 
   for (auto rp = result; rp != nullptr; rp = rp->ai_next) {
     char hbuf[NI_MAXHOST], sbuf[NI_MAXSERV];
+
+    // Let's skip all the IPv6 here
     if (rp->ai_family == AF_INET6) continue;
+
     getnameinfo(rp->ai_addr, rp->ai_addrlen, hbuf, sizeof(hbuf), sbuf, sizeof(sbuf), NI_NUMERICHOST | NI_NUMERICSERV);
     auto result = std::string(hbuf);
     bool duplicate = false;


### PR DESCRIPTION
Right now ZMQ only works with IPv4, so if the DNS tables have IPv6 in them, you can get IPv6 resolved. This PR fixes that.