### PR TITLE
Add thread-pinning method to ReusableThread

### DIFF
--- a/include/utilities/ReusableThread.hpp
+++ b/include/utilities/ReusableThread.hpp
@@ -43,6 +43,9 @@ public:
   // Set name for pthread handle
   void set_name(const std::string& name, int tid);
 
+  // Pin thread to CPU
+  void set_pin(int cpuid);
+
   // Check for completed task execution
   bool get_readiness() const { return m_task_executed; }
 
@@ -66,6 +69,7 @@ private:
   std::atomic<bool> m_task_assigned;
   std::atomic<bool> m_thread_quit;
   std::atomic<bool> m_worker_done;
+  std::atomic<bool> m_named;
   std::function<void()> m_task;
 
   // Locks


### PR DESCRIPTION
Convenience method to allow CPU pinning of ReusableThread instances from within an application.

Requires that the thread be named, adds member variable atomic boolean to track this.