### PR TITLE
Improved timestamp estimate between timesync reports

### DIFF
--- a/.github/workflows/dunedaq-v4-cpp-ci.yml
+++ b/.github/workflows/dunedaq-v4-cpp-ci.yml
@@ -5,7 +5,7 @@ name: build-develop
 on:
   push:
     branches: 
-      - develop
+      - production/v4
       - patch/*
       - prep-release/*
     paths-ignore:

--- a/.github/workflows/dunedaq-v4-cpp-ci.yml
+++ b/.github/workflows/dunedaq-v4-cpp-ci.yml
@@ -12,9 +12,9 @@ on:
       - 'docs/**'
       - '.github/**'
   pull_request:
-    branches: [ develop ]
+    branches: [ production/v4 ]
   schedule:
-    - cron: "0 7 * * *"
+    - cron: "0 9 * * *"
 
   workflow_dispatch:
 

--- a/.github/workflows/dunedaq-v4-cpp-ci.yml
+++ b/.github/workflows/dunedaq-v4-cpp-ci.yml
@@ -20,17 +20,15 @@ on:
 
 
 jobs:
-  Spack_Build_against_dev_release:
-    name: spack_build_against_dev_on_${{ matrix.os_name }}
+  Build_against_dev_release:
+    name: build_against_dev_on_${{ matrix.os_name }}
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     strategy:
       matrix:
         include:
-          - image: "ghcr.io/dune-daq/sl7-slim-externals:spack-dev-v1.1"
-            os_name: "c7"
-          - image: "ghcr.io/dune-daq/c8-slim-externals:spack-dev-v1.1"
-            os_name: "c8"
+          - image: "ghcr.io/dune-daq/nightly-release-alma9:production_v4"
+            os_name: "a9"
     container:
       image: ${{ matrix.image }}
     defaults:
@@ -51,10 +49,9 @@ jobs:
       run: |
           export REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
           source /cvmfs/dunedaq.opensciencegrid.org/setup_dunedaq.sh
-          setup_dbt latest|| true
+          setup_dbt latest || true
           release_name="last_fddaq"
-          #nd_config=$GITHUB_WORKSPACE/daq-release/configs/nddaq/nddaq-develop/release.yaml
-          #if grep -q "name: ${REPO}\n" $nd_config; then release_name="last_nddaq"; fi
+
           dbt-create -n $release_name dev-${{ matrix.os_name }}
 
     - name: checkout package for CI
@@ -63,32 +60,29 @@ jobs:
         path: ${{ github.repository }}
     
     - name: setup build env, build the repo against the development release
-      #- name: setup build env, build and lint the repo against the development release
       run: |
           export REPO=$(echo '${{ github.repository }}' | awk -F '/' '{print $2}')
           cd $GITHUB_WORKSPACE/dev-${{ matrix.os_name }}
           source env.sh || true
+
           spack unload $REPO || true
           cp -pr $GITHUB_WORKSPACE/DUNE-DAQ/$REPO $GITHUB_WORKSPACE/dev-${{ matrix.os_name }}/sourcecode
-          dbt-build
-          #[[ $REPO == "daq-cmake" ]] && dbt-build || dbt-build --lint
-          dbt-workarea-env
-          #dbt-build --unittest
+          dbt-build # --unittest # --lint
 
     - name: upload build log file
       uses: actions/upload-artifact@v3
       with:
-        name: spack_build_log_${{ matrix.os_name }}
+        name: build_log_${{ matrix.os_name }}
         path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/build*.log
 
-          #- name: upload linter output file
-          #uses: actions/upload-artifact@v3
-          #with:
-          #name: spack_linting_log_${{ matrix.os_name }}
-          #path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/linting*
+    # - name: upload linter output file
+    #   uses: actions/upload-artifact@v3
+    #   with:
+    #     name: linting_log_${{ matrix.os_name }}
+    #     path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/linting*
 
-          #- name: upload unittest output file
-          #uses: actions/upload-artifact@v2
-          #with:
-          #name: spack_unit_tests_log_${{ matrix.os_name }}
-          #path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/unit_tests*
+    # - name: upload unittest output file
+    #   uses: actions/upload-artifact@v3
+    #   with:
+    #     name: unit_tests_log_${{ matrix.os_name }}
+    #     path: ${{ github.workspace }}/dev-${{ matrix.os_name }}/log/unit_tests*

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,8 @@ daq_add_unit_test(Resolver_test           LINK_LIBRARIES logging::logging utilit
 daq_add_unit_test(ReusableThread_test           LINK_LIBRARIES logging::logging utilities)
 daq_add_unit_test(WorkerThread_test           LINK_LIBRARIES logging::logging utilities)
 daq_add_unit_test(NamedObject_test        )
-#daq_add_unit_test(TimestampEstimatorSystem_test  LINK_LIBRARIES utilities)
-#daq_add_unit_test(TimestampEstimator_test        LINK_LIBRARIES utilities)
+# daq_add_unit_test(TimestampEstimatorSystem_test  LINK_LIBRARIES utilities)
+daq_add_unit_test(TimestampEstimator_test        LINK_LIBRARIES utilities)
 
 daq_add_application(resolve_hostname resolve_hostname.cpp TEST LINK_LIBRARIES utilities)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,7 +19,7 @@ find_package(ers REQUIRED)
 
 # We don't have a real library, but we want to create a target for
 # dependents to be able to depend on
-daq_add_library(*.cpp LINK_LIBRARIES nlohmann_json::nlohmann_json logging::logging resolv)
+daq_add_library(*.cpp LINK_LIBRARIES nlohmann_json::nlohmann_json logging::logging resolv atomic)
 
 ##############################################################################
 

--- a/include/utilities/TimestampEstimator.hpp
+++ b/include/utilities/TimestampEstimator.hpp
@@ -33,7 +33,7 @@ public:
 
   virtual ~TimestampEstimator();
 
-  uint64_t get_timestamp_estimate() const override { return m_current_timestamp_estimate.load(); }
+  uint64_t get_timestamp_estimate() const override;
 
   void add_timestamp_datapoint(uint64_t daq_time, uint64_t system_time);
 

--- a/include/utilities/TimestampEstimator.hpp
+++ b/include/utilities/TimestampEstimator.hpp
@@ -43,7 +43,13 @@ public:
   uint64_t get_received_timesync_count() const { return m_received_timesync_count.load(); }
 private:
 
-  std::atomic<uint64_t> m_current_timestamp_estimate;
+  struct TimeSyncPoint {
+    uint64_t daq_time;
+    std::chrono::time_point<std::chrono::steady_clock> system_time;
+  };
+  
+  std::atomic<TimeSyncPoint> m_current_timestamp_estimate;
+
 
   uint64_t m_clock_frequency_hz; // NOLINT(build/unsigned)
   uint64_t m_most_recent_daq_time;

--- a/src/TimestampEstimator.cpp
+++ b/src/TimestampEstimator.cpp
@@ -37,6 +37,22 @@ TimestampEstimator::~TimestampEstimator()
 {
 }
 
+uint64_t
+TimestampEstimator::get_timestamp_estimate() const {
+  using namespace std::chrono;
+  
+  auto time_now = static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count()); // NOLINT
+  auto delta_time = time_now - m_most_recent_system_time;
+      
+  const uint64_t new_timestamp =
+    m_most_recent_daq_time + delta_time * m_clock_frequency_hz / 1000000;
+
+  return new_timestamp;
+  // return m_current_timestamp_estimate.load();
+}
+
+
+
 void
 TimestampEstimator::add_timestamp_datapoint(uint64_t daq_time, uint64_t system_time)
 {
@@ -60,7 +76,7 @@ TimestampEstimator::add_timestamp_datapoint(uint64_t daq_time, uint64_t system_t
     using namespace std::chrono;
 
     auto time_now =
-      static_cast<uint64_t>(duration_cast<microseconds>(system_clock::now().time_since_epoch()).count()); // NOLINT
+      static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count()); // NOLINT
 
     // (PAR 2021-07-22) We only want to _increase_ our timestamp
     // estimate, not _decrease_ it, so we only attempt the update if

--- a/src/TimestampEstimator.cpp
+++ b/src/TimestampEstimator.cpp
@@ -24,7 +24,7 @@ TimestampEstimator::TimestampEstimator(uint32_t run_number, uint64_t clock_frequ
 }
 
 TimestampEstimator::TimestampEstimator(uint64_t clock_frequency_hz) // NOLINT(build/unsigned)
-  : m_current_timestamp_estimate(std::numeric_limits<uint64_t>::max())
+  : m_current_timestamp_estimate(TimeSyncPoint{std::numeric_limits<uint64_t>::max(), std::chrono::time_point<std::chrono::steady_clock>()})
   , m_clock_frequency_hz(clock_frequency_hz)
   , m_most_recent_daq_time(0)
   , m_most_recent_system_time(0)
@@ -41,14 +41,15 @@ uint64_t
 TimestampEstimator::get_timestamp_estimate() const {
   using namespace std::chrono;
   
-  auto time_now = static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count()); // NOLINT
-  auto delta_time = time_now - m_most_recent_system_time;
+  TimeSyncPoint estimate = m_current_timestamp_estimate.load();
+  
+  auto delta_time_us = duration_cast<microseconds>(steady_clock::now() - estimate.system_time).count();
       
   const uint64_t new_timestamp =
-    m_most_recent_daq_time + delta_time * m_clock_frequency_hz / 1000000;
+    estimate.daq_time + delta_time_us * m_clock_frequency_hz / 1000000;
 
   return new_timestamp;
-  // return m_current_timestamp_estimate.load();
+
 }
 
 
@@ -56,14 +57,16 @@ TimestampEstimator::get_timestamp_estimate() const {
 void
 TimestampEstimator::add_timestamp_datapoint(uint64_t daq_time, uint64_t system_time)
 {
+    using namespace std::chrono;
+
   std::scoped_lock<std::mutex> lk(m_datapoint_mutex);
 
   // First, update the latest timestamp
-  uint64_t estimate = m_current_timestamp_estimate.load();
-  int64_t diff = estimate - daq_time;
+  TimeSyncPoint estimate = m_current_timestamp_estimate.load();
+  int64_t diff = estimate.daq_time - daq_time;
   TLOG_DEBUG(TLVL_TIME_SYNC_PROPERTIES) << "Got a TimeSync timestamp = " << daq_time
                                         << ", system time = " << system_time
-                                        << " when current timestamp estimate was " << estimate << ". diff=" << diff;
+                                        << " when current timestamp estimate was " << estimate.daq_time << ". diff=" << diff;
 
   if (m_most_recent_daq_time == std::numeric_limits<uint64_t>::max() ||
       daq_time > m_most_recent_daq_time) {
@@ -76,7 +79,8 @@ TimestampEstimator::add_timestamp_datapoint(uint64_t daq_time, uint64_t system_t
     using namespace std::chrono;
 
     auto time_now =
-      static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count()); // NOLINT
+      static_cast<uint64_t>(duration_cast<microseconds>(system_clock::now().time_since_epoch()).count()); // NOLINT
+    auto steady_time_now = steady_clock::now();
 
     // (PAR 2021-07-22) We only want to _increase_ our timestamp
     // estimate, not _decrease_ it, so we only attempt the update if
@@ -106,8 +110,8 @@ TimestampEstimator::add_timestamp_datapoint(uint64_t daq_time, uint64_t system_t
 
       // Don't ever decrease the timestamp; just wait until enough
       // time passes that we want to increase it
-      if (m_current_timestamp_estimate.load() == std::numeric_limits<uint64_t>::max() ||
-          new_timestamp >= m_current_timestamp_estimate.load()) {
+      if (estimate.daq_time == std::numeric_limits<uint64_t>::max() ||
+          new_timestamp >= estimate.daq_time) {
         TLOG_DEBUG(TLVL_TIME_SYNC_NEW_ESTIMATE)
           << "Storing new timestamp estimate of " << new_timestamp << " ticks (..." << std::fixed
           << std::setprecision(8)
@@ -117,10 +121,10 @@ TimestampEstimator::add_timestamp_datapoint(uint64_t daq_time, uint64_t system_t
           << (static_cast<double>(m_most_recent_daq_time % (m_clock_frequency_hz * 1000)) /
               static_cast<double>(m_clock_frequency_hz))
           << " sec), delta_time is " << delta_time << " usec, clock_freq is " << m_clock_frequency_hz << " Hz";
-        m_current_timestamp_estimate.store(new_timestamp);
+        m_current_timestamp_estimate.store(TimeSyncPoint{new_timestamp, steady_time_now});
       } else {
         TLOG_DEBUG(TLVL_TIME_SYNC_NOTES) << "Not updating timestamp estimate backwards from "
-                                         << m_current_timestamp_estimate.load() << " to " << new_timestamp;
+                                         << m_current_timestamp_estimate.load().daq_time << " to " << new_timestamp;
       }
     }
   }

--- a/unittest/TimestampEstimator_test.cxx
+++ b/unittest/TimestampEstimator_test.cxx
@@ -6,9 +6,9 @@
  * received with this code.
  */
 
-#include "iomanager/IOManager.hpp"
-#include "iomanager/Sender.hpp"
-#include "iomanager/Receiver.hpp"
+// #include "iomanager/IOManager.hpp"
+// #include "iomanager/Sender.hpp"
+// #include "iomanager/Receiver.hpp"
 #include "utilities/TimestampEstimator.hpp"
 
 /**
@@ -23,82 +23,120 @@
 #include <memory>
 #include <string>
 
+struct DummyTimeSync {
+  uint64_t daq_time{ std::numeric_limits<uint64_t>::max() };
+  /// The current system time
+  uint64_t system_time{ 0 };
+  /// Sequence Number of this message, for debugging
+  uint64_t sequence_number{ 0 }; // NOLINT(build/unsigned)
+  /// Run number at time of creation
+  uint32_t run_number{ 0 };
+  /// PID of the creating process, for debugging
+  uint32_t source_pid{ 0 }; // NOLINT(build/unsigned)
+};
+
 using namespace dunedaq;
 
 BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
 
-/**
- * @brief Initializes the QueueRegistry
- */
-struct DAQSinkDAQSourceTestFixture
-{
-  DAQSinkDAQSourceTestFixture() {}
+// /**
+//  * @brief Initializes the QueueRegistry
+//  */
+// struct DAQSinkDAQSourceTestFixture
+// {
+//   DAQSinkDAQSourceTestFixture() {}
 
-  void setup()
-  {
-    iomanager::ConnectionIds_t connections;
-    connections.emplace_back(
-      iomanager::ConnectionId{ "dummy", iomanager::ServiceType::kQueue, "TimeSync", "queue://kFollyMPMCQueue:100" });
+//   void setup()
+//   {
+//     iomanager::ConnectionIds_t connections;
+//     connections.emplace_back(
+//       iomanager::ConnectionId{ "dummy", iomanager::ServiceType::kQueue, "TimeSync", "queue://kFollyMPMCQueue:100" });
     
-    get_iomanager()->configure(connections);
-  }
+//     get_iomanager()->configure(connections);
+//   }
 
-  void teardown() {
-      get_iomanager()->reset();
-  }
-};
+//   void teardown() {
+//       get_iomanager()->reset();
+//   }
+// };
 
-BOOST_TEST_GLOBAL_FIXTURE(DAQSinkDAQSourceTestFixture);
+// BOOST_TEST_GLOBAL_FIXTURE(DAQSinkDAQSourceTestFixture);
 
 BOOST_AUTO_TEST_CASE(Basics)
 {
+  using namespace std::chrono;
   using namespace std::chrono_literals;
-  auto queue_ref = iomanager::ConnectionRef{ "queue", "dummy" };
-  auto sink =  get_iom_sender<dfmessages::TimeSync>(queue_ref);
-  auto source = get_iom_receiver<dfmessages::TimeSync>(queue_ref);
+  // // auto queue_ref = iomanager::ConnectionRef{ "queue", "dummy" };
+  // // auto sink =  get_iom_sender<dfmessages::TimeSync>(queue_ref);
+  // // auto source = get_iom_receiver<dfmessages::TimeSync>(queue_ref);
 
   const uint64_t clock_frequency_hz = 62'500'000; // NOLINT(build/unsigned)
 
-  utilities::TimestampEstimator te(source, clock_frequency_hz);
+  const uint32_t run_num = 5;
+  utilities::TimestampEstimator te(run_num, clock_frequency_hz);
 
-  // allow previous run timesync queue drain check to complete
-  std::this_thread::sleep_for(std::chrono::milliseconds(5));
 
-  // There's no valid timestamp yet, because no TimeSync messages have
-  // been received. We should immediately return with kInterrupted
-  std::atomic<bool> do_not_continue_flag{ false };
-  BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_not_continue_flag),
-                    utilities::TimestampEstimatorBase::kInterrupted);
+  
+  uint64_t daq_time_start = 1'000'000;
+  uint64_t system_time_start = static_cast<uint64_t>(duration_cast<microseconds>(system_clock::now().time_since_epoch()).count()); // NOLINT
+  uint64_t steady_time_start = static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count()); // NOLINT
 
-  std::atomic<bool> continue_flag{ true };
-  daqdataformats::timestamp_t initial_ts = 1;
-  dfmessages::TimeSync initial_time_sync(initial_ts);
-  sink->send(std::move(initial_time_sync), 10ms);
-  BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(continue_flag), utilities::TimestampEstimatorBase::kFinished);
+  DummyTimeSync ts;
+  ts.daq_time = daq_time_start;
+  ts.system_time = system_time_start;
+  ts.sequence_number = 1;
+  ts.run_number = run_num;
+  ts.source_pid = 12345;
 
-  daqdataformats::timestamp_t ts_now = te.get_timestamp_estimate();
+  te.timesync_callback(ts);
 
-  // Check that the timestamp has advanced a bit from the initial TimeSync, but not by "too much".
-  auto too_much = clock_frequency_hz / 10; // 100 ms
-  BOOST_CHECK_GE(ts_now, initial_ts);
-  BOOST_CHECK_LT(ts_now, initial_ts + too_much);
+  for( size_t i=0; i<100; ++i) {
 
-  BOOST_CHECK_EQUAL(te.wait_for_timestamp(ts_now + clock_frequency_hz, continue_flag),
-                    utilities::TimestampEstimatorBase::kFinished);
+    std::this_thread::sleep_for(10ms);
+    uint64_t steady_now = static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count());
+    uint64_t te_now = te.get_timestamp_estimate();
+    uint64_t te_diff = (te_now-daq_time_start) ;
+    std::cout << te_now << " diff = " << te_diff << " (" << te_diff*1'000'000/clock_frequency_hz << " us), steady us passed = " <<  steady_now - steady_time_start << std::endl;
+  }
 
-  ts_now = te.get_timestamp_estimate();
-  BOOST_CHECK_EQUAL(te.wait_for_timestamp(ts_now + clock_frequency_hz, do_not_continue_flag),
-                    utilities::TimestampEstimatorBase::kInterrupted);
+  // // allow previous run timesync queue drain check to complete
+  // std::this_thread::sleep_for(std::chrono::milliseconds(5));
 
-  // Check that the timestamp doesn't go backwards
-  daqdataformats::timestamp_t ts1 = te.get_timestamp_estimate();
-  BOOST_CHECK_GE(ts1, initial_ts);
-  daqdataformats::timestamp_t ts2 = te.get_timestamp_estimate();
-  BOOST_CHECK_GE(ts2, ts1);
-  // Check that the timestamp advances
-  std::this_thread::sleep_for(10ms);
-  daqdataformats::timestamp_t ts3 = te.get_timestamp_estimate();
-  BOOST_CHECK_GT(ts3, ts2);
+  // // There's no valid timestamp yet, because no TimeSync messages have
+  // // been received. We should immediately return with kInterrupted
+  // std::atomic<bool> do_not_continue_flag{ false };
+  // BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_not_continue_flag),
+  //                   utilities::TimestampEstimatorBase::kInterrupted);
+
+  // std::atomic<bool> continue_flag{ true };
+  // daqdataformats::timestamp_t initial_ts = 1;
+  // dfmessages::TimeSync initial_time_sync(initial_ts);
+  // sink->send(std::move(initial_time_sync), 10ms);
+  // BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(continue_flag), utilities::TimestampEstimatorBase::kFinished);
+
+  // daqdataformats::timestamp_t ts_now = te.get_timestamp_estimate();
+
+  // // Check that the timestamp has advanced a bit from the initial TimeSync, but not by "too much".
+  // auto too_much = clock_frequency_hz / 10; // 100 ms
+  // BOOST_CHECK_GE(ts_now, initial_ts);
+  // BOOST_CHECK_LT(ts_now, initial_ts + too_much);
+
+  // BOOST_CHECK_EQUAL(te.wait_for_timestamp(ts_now + clock_frequency_hz, continue_flag),
+  //                   utilities::TimestampEstimatorBase::kFinished);
+
+  // ts_now = te.get_timestamp_estimate();
+  // BOOST_CHECK_EQUAL(te.wait_for_timestamp(ts_now + clock_frequency_hz, do_not_continue_flag),
+  //                   utilities::TimestampEstimatorBase::kInterrupted);
+
+  // // Check that the timestamp doesn't go backwards
+  // daqdataformats::timestamp_t ts1 = te.get_timestamp_estimate();
+  // BOOST_CHECK_GE(ts1, initial_ts);
+  // daqdataformats::timestamp_t ts2 = te.get_timestamp_estimate();
+  // BOOST_CHECK_GE(ts2, ts1);
+  // // Check that the timestamp advances
+  // std::this_thread::sleep_for(10ms);
+  // daqdataformats::timestamp_t ts3 = te.get_timestamp_estimate();
+  // BOOST_CHECK_GT(ts3, ts2);
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/TimestampEstimator_test.cxx
+++ b/unittest/TimestampEstimator_test.cxx
@@ -66,17 +66,12 @@ BOOST_AUTO_TEST_CASE(Basics)
 {
   using namespace std::chrono;
   using namespace std::chrono_literals;
-  // // auto queue_ref = iomanager::ConnectionRef{ "queue", "dummy" };
-  // // auto sink =  get_iom_sender<dfmessages::TimeSync>(queue_ref);
-  // // auto source = get_iom_receiver<dfmessages::TimeSync>(queue_ref);
 
   const uint64_t clock_frequency_hz = 62'500'000; // NOLINT(build/unsigned)
 
   const uint32_t run_num = 5;
   utilities::TimestampEstimator te(run_num, clock_frequency_hz);
 
-
-  
   uint64_t daq_time_start = 1'000'000;
   uint64_t system_time_start = static_cast<uint64_t>(duration_cast<microseconds>(system_clock::now().time_since_epoch()).count()); // NOLINT
   uint64_t steady_time_start = static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count()); // NOLINT
@@ -95,48 +90,14 @@ BOOST_AUTO_TEST_CASE(Basics)
     std::this_thread::sleep_for(10ms);
     uint64_t steady_now = static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count());
     uint64_t te_now = te.get_timestamp_estimate();
-    uint64_t te_diff = (te_now-daq_time_start) ;
-    std::cout << te_now << " diff = " << te_diff << " (" << te_diff*1'000'000/clock_frequency_hz << " us), steady us passed = " <<  steady_now - steady_time_start << std::endl;
+    int64_t steady_diff = (steady_now - steady_time_start);
+    int64_t te_diff = (te_now-daq_time_start);
+    int64_t dd = te_diff-(steady_diff*clock_frequency_hz/1'000'000);
+
+    BOOST_CHECK_LT(abs(dd), 1'000);
+
   }
-
-  // // allow previous run timesync queue drain check to complete
-  // std::this_thread::sleep_for(std::chrono::milliseconds(5));
-
-  // // There's no valid timestamp yet, because no TimeSync messages have
-  // // been received. We should immediately return with kInterrupted
-  // std::atomic<bool> do_not_continue_flag{ false };
-  // BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_not_continue_flag),
-  //                   utilities::TimestampEstimatorBase::kInterrupted);
-
-  // std::atomic<bool> continue_flag{ true };
-  // daqdataformats::timestamp_t initial_ts = 1;
-  // dfmessages::TimeSync initial_time_sync(initial_ts);
-  // sink->send(std::move(initial_time_sync), 10ms);
-  // BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(continue_flag), utilities::TimestampEstimatorBase::kFinished);
-
-  // daqdataformats::timestamp_t ts_now = te.get_timestamp_estimate();
-
-  // // Check that the timestamp has advanced a bit from the initial TimeSync, but not by "too much".
-  // auto too_much = clock_frequency_hz / 10; // 100 ms
-  // BOOST_CHECK_GE(ts_now, initial_ts);
-  // BOOST_CHECK_LT(ts_now, initial_ts + too_much);
-
-  // BOOST_CHECK_EQUAL(te.wait_for_timestamp(ts_now + clock_frequency_hz, continue_flag),
-  //                   utilities::TimestampEstimatorBase::kFinished);
-
-  // ts_now = te.get_timestamp_estimate();
-  // BOOST_CHECK_EQUAL(te.wait_for_timestamp(ts_now + clock_frequency_hz, do_not_continue_flag),
-  //                   utilities::TimestampEstimatorBase::kInterrupted);
-
-  // // Check that the timestamp doesn't go backwards
-  // daqdataformats::timestamp_t ts1 = te.get_timestamp_estimate();
-  // BOOST_CHECK_GE(ts1, initial_ts);
-  // daqdataformats::timestamp_t ts2 = te.get_timestamp_estimate();
-  // BOOST_CHECK_GE(ts2, ts1);
-  // // Check that the timestamp advances
-  // std::this_thread::sleep_for(10ms);
-  // daqdataformats::timestamp_t ts3 = te.get_timestamp_estimate();
-  // BOOST_CHECK_GT(ts3, ts2);
 }
+
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Timestamp estimates requested between the reception of timesyncs return the same number, which is an issue in some contexts (i.e. trigger rate generation at rate > than the timesync rate).
This PR tries to mitigate this issue by improve the estimate using the PC steady clock to correct for the time passed between the last timesync and the estimate request.