### PR TITLE
Skip TimeSync messages in TimestampEstimator from the same process

### DIFF
--- a/include/utilities/TimestampEstimator.hpp
+++ b/include/utilities/TimestampEstimator.hpp
@@ -57,6 +57,7 @@ private:
   std::mutex m_datapoint_mutex;
   uint32_t m_run_number {0};
   std::atomic<uint64_t> m_received_timesync_count; // NOLINT(build/unsigned)
+  uint32_t m_current_process_id;
 };
 
 } // namespace utilities

--- a/include/utilities/detail/TimestampEstimator.hxx
+++ b/include/utilities/detail/TimestampEstimator.hxx
@@ -10,11 +10,11 @@ void TimestampEstimator::timesync_callback(const T& tsync)
   TLOG_DEBUG(TLVL_TIME_SYNC_PROPERTIES) << "Got a TimeSync run=" << tsync.run_number << " local run=" << m_run_number 
                                         << " seqno=" << tsync.sequence_number
                                         << " source_pid=" << tsync.source_pid;
-  if (tsync.run_number == m_run_number) {
+  if (tsync.run_number == m_run_number && tsync.source_pid != m_current_process_id) {
     add_timestamp_datapoint(tsync.daq_time, tsync.system_time);
   } else {
     TLOG_DEBUG(0) << "Discarded TimeSync message from run " << tsync.run_number << " during run "
-                  << m_run_number;
+                  << m_run_number << " with pid " << tsync.source_pid << " and timestamp " << tsync.daq_time;
   }
 }
 

--- a/src/TimestampEstimator.cpp
+++ b/src/TimestampEstimator.cpp
@@ -12,6 +12,7 @@
 #include "logging/Logging.hpp"
 
 #include <memory>
+#include <unistd.h>
 
 #define TRACE_NAME "TimestampEstimator" // NOLINT
 
@@ -31,6 +32,7 @@ TimestampEstimator::TimestampEstimator(uint64_t clock_frequency_hz) // NOLINT(bu
   , m_run_number(0)
   , m_received_timesync_count(0)
 {
+  m_current_process_id = static_cast<uint32_t>(getpid());
 }
 
 TimestampEstimator::~TimestampEstimator()


### PR DESCRIPTION
Summary: Added a small change to TimestampEstimator to have it skip TimeSync messages sent from the same process ID.  This can happen when the FakeHSI sends out TimeSyncs.

As mentioned in the Core Software meeting today (26-Jun-2024), there is a long-standing feature that our emulated-data system configurations include the sending of TimeSync messages from the FakeHSI to itself.  It would be great to fix this in the `daqconf` package, but given the limited lifetime of configurations created by `daqconf`, it seems reasonable to remove these TimeSync messags in the easiest way possible.  This PR provides such a way - by dropping TimeSync messages that are sent from the same Linux ProcessID as the current process.

Fixing this problem now will be helpful because it is contributing to failures in the PDS/DAPHNE part of the `readout_type_scan` automated integration test in patch release fddaq-v4.4.3.  

There are a couple of ways to test this change:

1. look at the errors reported both without and with this change:
    1. create a software area for the fddaq-v4.4.3 release (e.g. [here](https://github.com/DUNE-DAQ/daqconf/wiki/Instructions-for-setting-up-an-fddaq%E2%80%90v4.4.3-software-area)), run the `readout_type_scan` integtest (e.g. `daqsystemtest_integtest_bundle.sh -s 2 -f 1 -l 1`, and note the large number of errors associated with the PDS/DAPHNE part of the test (including ones that mention `The most recent TimeSync message is behind current system time by X`).  Then, add this branch of the `utilities` package and the `patch/fddaq-v4.4.x` branch of the `hsilibs` package to your software area, recompile, and re-run the test.  With this change included, the number of reported errors and warnings should decrease, but probably will not disappear completely without include additional changes.
2. look at TRACE messages to see the unwanted TimeSync messages being skipped
    1. specify a TRACE memory file to be used (e.g. `export TRACE_FILE=$DBT_AREA_ROOT/log/$USER.trace`) and then re-run the integtest.  Then use `tshow | tdelta -ct 1 | grep 'Discarded TimeSync' | more` to see the expected TRACE messages.

