### PR TITLE
Implement an exponential backoff in TimestampEstimatorBase::wait_for_timestamp

### DIFF
--- a/include/utilities/TimestampEstimator.hpp
+++ b/include/utilities/TimestampEstimator.hpp
@@ -35,6 +35,8 @@ public:
 
   uint64_t get_timestamp_estimate() const override;
 
+  std::chrono::microseconds get_wait_estimate(uint64_t ts) const override;
+
   void add_timestamp_datapoint(uint64_t daq_time, uint64_t system_time);
 
   template <class T>

--- a/include/utilities/TimestampEstimatorBase.hpp
+++ b/include/utilities/TimestampEstimatorBase.hpp
@@ -10,6 +10,7 @@
 #define UTILITIES_INCLUDE_UTILITIES_TIMESTAMPESTIMATORBASE_HPP_
 
 #include <atomic>
+#include <chrono>
 
 namespace dunedaq {
 namespace utilities {
@@ -24,6 +25,7 @@ class TimestampEstimatorBase
 public:
   virtual ~TimestampEstimatorBase() = default;
   virtual uint64_t get_timestamp_estimate() const = 0;
+  virtual std::chrono::microseconds get_wait_estimate(uint64_t ts) const = 0;
 
   enum WaitStatus
   {

--- a/include/utilities/TimestampEstimatorSystem.hpp
+++ b/include/utilities/TimestampEstimatorSystem.hpp
@@ -26,6 +26,8 @@ public:
 
   uint64_t get_timestamp_estimate() const override;
 
+  std::chrono::microseconds get_wait_estimate(uint64_t ts) const override;
+
 private:
   uint64_t m_clock_frequency_hz; // NOLINT(build/unsigned)
 };

--- a/src/TimestampEstimator.cpp
+++ b/src/TimestampEstimator.cpp
@@ -54,6 +54,13 @@ TimestampEstimator::get_timestamp_estimate() const {
 
 }
 
+std::chrono::microseconds
+TimestampEstimator::get_wait_estimate(uint64_t ts) const
+{
+  auto now = get_timestamp_estimate();
+  auto diff = ts - now;
+  return std::chrono::microseconds(static_cast<long>(diff * 1000000. / m_clock_frequency_hz));
+}
 
 
 void

--- a/src/TimestampEstimator.cpp
+++ b/src/TimestampEstimator.cpp
@@ -25,7 +25,8 @@ TimestampEstimator::TimestampEstimator(uint32_t run_number, uint64_t clock_frequ
 }
 
 TimestampEstimator::TimestampEstimator(uint64_t clock_frequency_hz) // NOLINT(build/unsigned)
-  : m_current_timestamp_estimate(TimeSyncPoint{std::numeric_limits<uint64_t>::max(), std::chrono::time_point<std::chrono::steady_clock>()})
+  : m_current_timestamp_estimate(
+      TimeSyncPoint{ std::numeric_limits<uint64_t>::max(), std::chrono::time_point<std::chrono::steady_clock>() })
   , m_clock_frequency_hz(clock_frequency_hz)
   , m_most_recent_daq_time(0)
   , m_most_recent_system_time(0)
@@ -35,38 +36,36 @@ TimestampEstimator::TimestampEstimator(uint64_t clock_frequency_hz) // NOLINT(bu
   m_current_process_id = static_cast<uint32_t>(getpid());
 }
 
-TimestampEstimator::~TimestampEstimator()
-{
-}
+TimestampEstimator::~TimestampEstimator() {}
 
 uint64_t
-TimestampEstimator::get_timestamp_estimate() const {
+TimestampEstimator::get_timestamp_estimate() const
+{
   using namespace std::chrono;
-  
+
   TimeSyncPoint estimate = m_current_timestamp_estimate.load();
-  
+
   auto delta_time_us = duration_cast<microseconds>(steady_clock::now() - estimate.system_time).count();
-      
-  const uint64_t new_timestamp =
-    estimate.daq_time + delta_time_us * m_clock_frequency_hz / 1000000;
+
+  const uint64_t new_timestamp = estimate.daq_time + delta_time_us * m_clock_frequency_hz / 1000000;
 
   return new_timestamp;
-
 }
 
 std::chrono::microseconds
 TimestampEstimator::get_wait_estimate(uint64_t ts) const
 {
   auto now = get_timestamp_estimate();
+  if (now > ts)
+    return std::chrono::microseconds(0);
   auto diff = ts - now;
   return std::chrono::microseconds(static_cast<long>(diff * 1000000. / m_clock_frequency_hz));
 }
 
-
 void
 TimestampEstimator::add_timestamp_datapoint(uint64_t daq_time, uint64_t system_time)
 {
-    using namespace std::chrono;
+  using namespace std::chrono;
 
   std::scoped_lock<std::mutex> lk(m_datapoint_mutex);
 
@@ -74,11 +73,10 @@ TimestampEstimator::add_timestamp_datapoint(uint64_t daq_time, uint64_t system_t
   TimeSyncPoint estimate = m_current_timestamp_estimate.load();
   int64_t diff = estimate.daq_time - daq_time;
   TLOG_DEBUG(TLVL_TIME_SYNC_PROPERTIES) << "Got a TimeSync timestamp = " << daq_time
-                                        << ", system time = " << system_time
-                                        << " when current timestamp estimate was " << estimate.daq_time << ". diff=" << diff;
+                                        << ", system time = " << system_time << " when current timestamp estimate was "
+                                        << estimate.daq_time << ". diff=" << diff;
 
-  if (m_most_recent_daq_time == std::numeric_limits<uint64_t>::max() ||
-      daq_time > m_most_recent_daq_time) {
+  if (m_most_recent_daq_time == std::numeric_limits<uint64_t>::max() || daq_time > m_most_recent_daq_time) {
     m_most_recent_daq_time = daq_time;
     m_most_recent_system_time = system_time;
   }
@@ -114,13 +112,11 @@ TimestampEstimator::add_timestamp_datapoint(uint64_t daq_time, uint64_t system_t
       if (delta_time > 1e6)
         ers::warning(LateTimeSync(ERS_HERE, delta_time));
 
-      const uint64_t new_timestamp =
-        m_most_recent_daq_time + delta_time * m_clock_frequency_hz / 1000000;
+      const uint64_t new_timestamp = m_most_recent_daq_time + delta_time * m_clock_frequency_hz / 1000000;
 
       // Don't ever decrease the timestamp; just wait until enough
       // time passes that we want to increase it
-      if (estimate.daq_time == std::numeric_limits<uint64_t>::max() ||
-          new_timestamp >= estimate.daq_time) {
+      if (estimate.daq_time == std::numeric_limits<uint64_t>::max() || new_timestamp >= estimate.daq_time) {
         TLOG_DEBUG(TLVL_TIME_SYNC_NEW_ESTIMATE)
           << "Storing new timestamp estimate of " << new_timestamp << " ticks (..." << std::fixed
           << std::setprecision(8)
@@ -130,7 +126,7 @@ TimestampEstimator::add_timestamp_datapoint(uint64_t daq_time, uint64_t system_t
           << (static_cast<double>(m_most_recent_daq_time % (m_clock_frequency_hz * 1000)) /
               static_cast<double>(m_clock_frequency_hz))
           << " sec), delta_time is " << delta_time << " usec, clock_freq is " << m_clock_frequency_hz << " Hz";
-        m_current_timestamp_estimate.store(TimeSyncPoint{new_timestamp, steady_time_now});
+        m_current_timestamp_estimate.store(TimeSyncPoint{ new_timestamp, steady_time_now });
       } else {
         TLOG_DEBUG(TLVL_TIME_SYNC_NOTES) << "Not updating timestamp estimate backwards from "
                                          << m_current_timestamp_estimate.load().daq_time << " to " << new_timestamp;

--- a/src/TimestampEstimatorBase.cpp
+++ b/src/TimestampEstimatorBase.cpp
@@ -15,8 +15,12 @@ namespace utilities {
 TimestampEstimatorBase::WaitStatus
 TimestampEstimatorBase::wait_for_valid_timestamp(std::atomic<bool>& continue_flag)
 {
+  auto sleep_time = std::chrono::microseconds(1);
   while (continue_flag.load() && get_timestamp_estimate() == std::numeric_limits<uint64_t>::max()) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(sleep_time);
+    if (sleep_time < std::chrono::milliseconds(10)) {
+      sleep_time *= 2;
+    }
   }
 
   return continue_flag.load() ? TimestampEstimatorBase::kFinished : TimestampEstimatorBase::kInterrupted;
@@ -25,9 +29,13 @@ TimestampEstimatorBase::wait_for_valid_timestamp(std::atomic<bool>& continue_fla
 TimestampEstimatorBase::WaitStatus
 TimestampEstimatorBase::wait_for_timestamp(uint64_t ts, std::atomic<bool>& continue_flag)
 {
+  auto sleep_time = std::chrono::microseconds(1);
   while (continue_flag.load() &&
          (get_timestamp_estimate() < ts || get_timestamp_estimate() == std::numeric_limits<uint64_t>::max())) {
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    std::this_thread::sleep_for(sleep_time);
+    if (sleep_time < std::chrono::milliseconds(10)) {
+      sleep_time *= 2;
+    }
   }
 
   return continue_flag.load() ? TimestampEstimatorBase::kFinished : TimestampEstimatorBase::kInterrupted;

--- a/src/TimestampEstimatorBase.cpp
+++ b/src/TimestampEstimatorBase.cpp
@@ -32,7 +32,7 @@ TimestampEstimatorBase::wait_for_timestamp(uint64_t ts, std::atomic<bool>& conti
   auto get_sleep_time = [this, ts]() {
     auto est = get_wait_estimate(ts);
     auto pest = static_cast<long>(est.count() * 0.8);
-    if (pest < 1)
+    if (pest < 1 && est != std::chrono::microseconds(0))
       return std::chrono::microseconds(1);
     return std::chrono::microseconds(pest);
   };

--- a/src/TimestampEstimatorBase.cpp
+++ b/src/TimestampEstimatorBase.cpp
@@ -29,13 +29,18 @@ TimestampEstimatorBase::wait_for_valid_timestamp(std::atomic<bool>& continue_fla
 TimestampEstimatorBase::WaitStatus
 TimestampEstimatorBase::wait_for_timestamp(uint64_t ts, std::atomic<bool>& continue_flag)
 {
-  auto sleep_time = std::chrono::microseconds(1);
+  auto get_sleep_time = [this, ts]() {
+    auto est = get_wait_estimate(ts);
+    auto pest = static_cast<long>(est.count() * 0.8);
+    if (pest < 1)
+      return std::chrono::microseconds(1);
+    return std::chrono::microseconds(pest);
+  };
+  auto sleep_time = get_sleep_time();
   while (continue_flag.load() &&
          (get_timestamp_estimate() < ts || get_timestamp_estimate() == std::numeric_limits<uint64_t>::max())) {
     std::this_thread::sleep_for(sleep_time);
-    if (sleep_time < std::chrono::milliseconds(10)) {
-      sleep_time *= 2;
-    }
+    sleep_time = get_sleep_time();
   }
 
   return continue_flag.load() ? TimestampEstimatorBase::kFinished : TimestampEstimatorBase::kInterrupted;

--- a/src/TimestampEstimatorSystem.cpp
+++ b/src/TimestampEstimatorSystem.cpp
@@ -30,5 +30,15 @@ TimestampEstimatorSystem::get_timestamp_estimate() const
   return (m_clock_frequency_hz / 1000000.) * now_us.count();
 }
 
+std::chrono::microseconds
+TimestampEstimatorSystem::get_wait_estimate(uint64_t ts) const
+{
+  auto now = std::chrono::system_clock::now().time_since_epoch();
+  auto now_us = std::chrono::duration_cast<std::chrono::microseconds>(now);
+  auto then = static_cast<long>(ts * 1000000. / m_clock_frequency_hz);
+  auto then_us = std::chrono::microseconds(then);
+  return then_us - now_us;
+}
+
 } // namespace utilities
 } // namespace dunedaq

--- a/src/TimestampEstimatorSystem.cpp
+++ b/src/TimestampEstimatorSystem.cpp
@@ -37,6 +37,8 @@ TimestampEstimatorSystem::get_wait_estimate(uint64_t ts) const
   auto now_us = std::chrono::duration_cast<std::chrono::microseconds>(now);
   auto then = static_cast<long>(ts * 1000000. / m_clock_frequency_hz);
   auto then_us = std::chrono::microseconds(then);
+  if (then_us < now_us)
+    return std::chrono::microseconds(0);
   return then_us - now_us;
 }
 


### PR DESCRIPTION
Includes the changes in #39, tries to resolve #31 by starting with a 1us wait and doubling each loop iteration until reaching a maximum of 10ms.