### PR TITLE
Include logging/Logging.hpp whenever ERS issues are declared, includi…

### DIFF
--- a/include/utilities/Issues.hpp
+++ b/include/utilities/Issues.hpp
@@ -9,7 +9,7 @@
 #define UTILITIES_INCLUDE_UTILITIES_ISSUES_HPP_
 
 #include <ers/Issue.hpp>
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <string>
 

--- a/include/utilities/Issues.hpp
+++ b/include/utilities/Issues.hpp
@@ -9,6 +9,7 @@
 #define UTILITIES_INCLUDE_UTILITIES_ISSUES_HPP_
 
 #include <ers/Issue.hpp>
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <string>
 

--- a/include/utilities/WorkerThread.hpp
+++ b/include/utilities/WorkerThread.hpp
@@ -17,6 +17,7 @@
 #define UTILITIES_INCLUDE_UTILITIES_WORKERTHREAD_HPP_
 
 #include "ers/ers.hpp"
+#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <functional>
 #include <future>

--- a/include/utilities/WorkerThread.hpp
+++ b/include/utilities/WorkerThread.hpp
@@ -17,7 +17,7 @@
 #define UTILITIES_INCLUDE_UTILITIES_WORKERTHREAD_HPP_
 
 #include "ers/ers.hpp"
-#include <logging/Logging.hpp> // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
+#include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <functional>
 #include <future>


### PR DESCRIPTION
…ng note on why (TLOG() << ERSIssue only works when Logging.hpp included first)