### PR TITLE
Fixed a couple of bugs in TimestampEstimator and TimestampEstimatorBase

### DIFF
--- a/src/TimestampEstimator.cpp
+++ b/src/TimestampEstimator.cpp
@@ -38,12 +38,20 @@ TimestampEstimator::TimestampEstimator(uint64_t clock_frequency_hz) // NOLINT(bu
 
 TimestampEstimator::~TimestampEstimator() {}
 
+/**
+ * @brief Returns the current timestamp estimate or a special value if no valid timestamp is available
+ * @return the current estimated timestamp (in units of DUNE Timing System ticks) or
+ *         std::numeric_limits<uint64_t>::max() if no valid timestamp is currently available
+ */
 uint64_t
 TimestampEstimator::get_timestamp_estimate() const
 {
   using namespace std::chrono;
 
   TimeSyncPoint estimate = m_current_timestamp_estimate.load();
+  // 27-May-2025, KAB: added check if a valid timestamp is available and, if not, return early
+  // with the special value that indicates that none is available.
+  if (estimate.daq_time == std::numeric_limits<uint64_t>::max()) {return estimate.daq_time;}
 
   auto delta_time_us = duration_cast<microseconds>(steady_clock::now() - estimate.system_time).count();
 

--- a/src/TimestampEstimatorBase.cpp
+++ b/src/TimestampEstimatorBase.cpp
@@ -12,6 +12,17 @@
 
 namespace dunedaq {
 namespace utilities {
+
+/**
+ * @brief Waits for a valid timestamp to become available.  Returns a status value that
+ *        indicates whether a valid timestamp is available or not.
+ * @param continue_flag whether to continue waiting until a valid timestamp is available
+ *        or return immediately
+ * @details The value of the continue_flag can be changed from true to false externally
+ *          to this method, and that will cause the method to exit soon thereafter
+ *          (on the order of 10 msec) and return the current status.
+ * @return kFinished if a valid timestamp is available or kInterrupted if one is not
+ */
 TimestampEstimatorBase::WaitStatus
 TimestampEstimatorBase::wait_for_valid_timestamp(std::atomic<bool>& continue_flag)
 {
@@ -23,7 +34,9 @@ TimestampEstimatorBase::wait_for_valid_timestamp(std::atomic<bool>& continue_fla
     }
   }
 
-  return continue_flag.load() ? TimestampEstimatorBase::kFinished : TimestampEstimatorBase::kInterrupted;
+  // 27-May-2025, KAB: modified this return statement so that the return code is based on whether a
+  // valid timestamp is available (instead of whether the caller asked the method to wait or not)
+  return (get_timestamp_estimate() != std::numeric_limits<uint64_t>::max()) ? TimestampEstimatorBase::kFinished : TimestampEstimatorBase::kInterrupted;
 }
 
 TimestampEstimatorBase::WaitStatus

--- a/unittest/TimestampEstimator_test.cxx
+++ b/unittest/TimestampEstimator_test.cxx
@@ -18,7 +18,9 @@
 
 #include "boost/test/unit_test.hpp"
 
+#include <atomic>
 #include <chrono>
+#include <future>
 #include <map>
 #include <memory>
 #include <string>
@@ -99,5 +101,106 @@ BOOST_AUTO_TEST_CASE(Basics)
   }
 }
 
+// 27-May-2025, KAB: this test case is intended to verify that an instance of
+// the TimestampEstimator behaves as expected when it first starts up.
+BOOST_AUTO_TEST_CASE(StartupBehavior)
+{
+  using namespace std::chrono;
+  using namespace std::chrono_literals;
+
+  const uint64_t clock_frequency_hz = 62'500'000; // NOLINT(build/unsigned)
+
+  const uint32_t run_num = 5;
+  utilities::TimestampEstimator te(run_num, clock_frequency_hz);
+
+  uint64_t daq_time_start = 1'000'000;
+  uint64_t system_time_start = static_cast<uint64_t>(duration_cast<microseconds>(system_clock::now().time_since_epoch()).count()); // NOLINT
+  uint64_t steady_time_start = static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count()); // NOLINT
+
+  // create a dummy TimeSync message for later use
+  DummyTimeSync ts;
+  ts.daq_time = daq_time_start;
+  ts.system_time = system_time_start;
+  ts.sequence_number = 1;
+  ts.run_number = run_num;
+  ts.source_pid = 12345;
+
+  std::atomic<bool> do_not_continue_flag{ false };
+  std::atomic<bool> do_continue_flag{ true };
+  std::atomic<bool> continue_flag_for_thread{ true };
+  std::atomic<bool> thread_has_finished{ false };
+  std::atomic<utilities::TimestampEstimatorBase::WaitStatus> return_code_from_thread_wait{ dunedaq::utilities::TimestampEstimatorBase::kInterrupted };
+
+  // spawn a thread that waits until the TSE can provide a valid timestamp
+  std::function<void()> valid_timestamp_wait_func = [&]() {
+    return_code_from_thread_wait = te.wait_for_valid_timestamp(continue_flag_for_thread);
+    thread_has_finished = true;
+  };
+  auto wait_ftr = std::async(std::launch::async, valid_timestamp_wait_func);
+
+  // verify that a TSE instance that hasn't received any TimeSync messages returns
+  // a special value that indicates that it can't yet provide a valid timestamp
+  // when we ask it for the current timestamp estimate.
+  // Also, verify that the wait thread is still waiting.
+  for( size_t i=0; i<10; ++i) {
+
+    std::this_thread::sleep_for(100ms);
+    uint64_t te_now = te.get_timestamp_estimate();
+    BOOST_CHECK_EQUAL(te_now, std::numeric_limits<uint64_t>::max());
+
+    BOOST_CHECK_EQUAL(thread_has_finished, false);
+
+  }
+
+  // if we ask the TSE if it has a valid timestamp, and we tell it that it doesn't
+  // need to wait until it gets one, AND the TSE instance has not yet received
+  // a TimeSync message, it should return immediately and tell us that it is returning
+  // without being able to provide a valid timestamp (kInterrupted).
+  BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_not_continue_flag),
+                    dunedaq::utilities::TimestampEstimatorBase::kInterrupted);
+  BOOST_CHECK_EQUAL(thread_has_finished, false);
+
+  // pass a TimeSync message into the TSE instance
+  te.timesync_callback(ts);
+
+  // verify that the wait thread has finished and it received the expected return code
+  std::this_thread::sleep_for(std::chrono::milliseconds(25));
+  BOOST_CHECK_EQUAL(thread_has_finished, true);
+  BOOST_CHECK_EQUAL(return_code_from_thread_wait, dunedaq::utilities::TimestampEstimatorBase::kFinished);
+  // if the thread has not finished, tell it to finish now
+  if (! thread_has_finished) {continue_flag_for_thread.store(false);}
+
+  // verify that the TSE instance now provides valid timestamps and those
+  // timestamp track closely to wallclock time (computer system time)
+  for( size_t i=0; i<10; ++i) {
+
+    std::this_thread::sleep_for(100ms);
+    uint64_t steady_now = static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count());
+    uint64_t te_now = te.get_timestamp_estimate();
+    int64_t steady_diff = (steady_now - steady_time_start);
+    int64_t te_diff = (te_now-daq_time_start);
+    int64_t dd = te_diff-(steady_diff*clock_frequency_hz/1'000'000);
+
+    BOOST_CHECK_LT(abs(dd), 1'000);
+
+  }
+
+  // now the TSE instance "wait" method should return immediately with a status
+  // that indicates that it *does* have a valid timestamp, independent of whether
+  // we tell it to wait for a valid timestamp or not
+  BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_not_continue_flag),
+                    dunedaq::utilities::TimestampEstimatorBase::kFinished);
+  BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_continue_flag),
+                    dunedaq::utilities::TimestampEstimatorBase::kFinished);
+
+}
+
+BOOST_AUTO_TEST_CASE(AdditionalTestIdeas)
+{
+  // slow clock
+  // fast clock
+  // non-standard clock frequency
+  // bursts and delays
+}
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
The former was causing the `RandomTriggerCandidateMaker` to produce an incorrect interval between the first two triggers in a run. Tests were added to `TimestampEstimator_test.cxx` to demonstrate the problems (before the fixes were made) and validate the changes.

The first problem was uncovered when the `long_window_readout_test.py` (regression test in the `daqsystemtest` repo) recently started failing occasionally.  These failures were trace to a 15-16 second interval between the first two triggers in a run, instead of the requested 20 second interval.  And, that behavior from the RTCM was traced to the bug in `TimestampEstimator::get_timestamp_estimate()` method.  (It is not clear why the regression tests just started showing the problem recently...)

To test these changes, one would need to create a software area based on a recent fddaq-v5.3.2 release candidate, include this repo and the trigger repo in the software area, rebuild, run the unit tests (`dbt-unittest-summary.sh`), and run the daqsystemtest regression tests (`daqsystemtest_integtest_bundle.sh --stop-on-fail`).
