### PR TITLE
Address review items related to the TimestampEstimator classes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,8 +33,8 @@ daq_add_unit_test(Resolver_test           LINK_LIBRARIES logging::logging utilit
 daq_add_unit_test(ReusableThread_test           LINK_LIBRARIES logging::logging utilities)
 daq_add_unit_test(WorkerThread_test           LINK_LIBRARIES logging::logging utilities)
 daq_add_unit_test(NamedObject_test        )
-# daq_add_unit_test(TimestampEstimatorSystem_test  LINK_LIBRARIES utilities)
-daq_add_unit_test(TimestampEstimator_test        LINK_LIBRARIES utilities)
+daq_add_unit_test(TimestampEstimatorSystem_test  LINK_LIBRARIES utilities)
+daq_add_unit_test(TimestampEstimatorTimeSync_test        LINK_LIBRARIES utilities)
 
 daq_add_application(resolve_hostname resolve_hostname.cpp TEST LINK_LIBRARIES utilities)
 

--- a/include/utilities/Issues.hpp
+++ b/include/utilities/Issues.hpp
@@ -8,14 +8,9 @@
 #ifndef UTILITIES_INCLUDE_UTILITIES_ISSUES_HPP_
 #define UTILITIES_INCLUDE_UTILITIES_ISSUES_HPP_
 
-#include <ers/Issue.hpp>
 #include "logging/Logging.hpp" // NOTE: if ISSUES ARE DECLARED BEFORE include logging/Logging.hpp, TLOG_DEBUG<<issue wont work.
 
 #include <string>
-
-#define TLVL_TIME_SYNC_PROPERTIES 17
-#define TLVL_TIME_SYNC_NOTES 18
-#define TLVL_TIME_SYNC_NEW_ESTIMATE 19
 
 namespace dunedaq {
 

--- a/include/utilities/TimestampEstimatorBase.hpp
+++ b/include/utilities/TimestampEstimatorBase.hpp
@@ -1,5 +1,7 @@
 /**
- * @file TimestampEstimatorSystem.hpp TimestampEstimatorSystem Class
+ * @file TimestampEstimatorBase.hpp TimestampEstimatorBase Class
+ *
+ * This is the base class for the TimestampEstimator implementations
  *
  * This is part of the DUNE DAQ Application Framework, copyright 2020.
  * Licensing/copyright details are in the COPYING file that you should have

--- a/include/utilities/TimestampEstimatorBase.hpp
+++ b/include/utilities/TimestampEstimatorBase.hpp
@@ -23,6 +23,8 @@ namespace utilities {
 class TimestampEstimatorBase
 {
 public:
+  static constexpr uint64_t s_invalid_ts = std::numeric_limits<uint64_t>::max();
+
   virtual ~TimestampEstimatorBase() = default;
   virtual uint64_t get_timestamp_estimate() const = 0;
   virtual std::chrono::microseconds get_wait_estimate(uint64_t ts) const = 0;
@@ -40,7 +42,12 @@ public:
 
      Returns kFinished if the timestamp became valid, or kInterrupted if continue_flag became false first
   */
-  WaitStatus wait_for_valid_timestamp(std::atomic<bool>& continue_flag);
+  WaitStatus wait_for_valid_timestamp(std::atomic<bool>& continue_flag)
+  {
+    uint64_t ts_discard = s_invalid_ts;
+    return wait_for_valid_timestamp(continue_flag, ts_discard);
+  }
+  WaitStatus wait_for_valid_timestamp(std::atomic<bool>& continue_flag, uint64_t& last_seen_ts);
 
   /**
      Wait for the current timestamp estimate to reach ts, or for
@@ -48,7 +55,12 @@ public:
 
      Returns kFinished if the timestamp became valid, or kInterrupted if continue_flag became false first
   */
-  WaitStatus wait_for_timestamp(uint64_t ts, std::atomic<bool>& continue_flag);
+  WaitStatus wait_for_requested_timestamp(uint64_t ts, std::atomic<bool>& continue_flag)
+  {
+    uint64_t ts_discard = s_invalid_ts;
+    return wait_for_requested_timestamp(ts, continue_flag, ts_discard);
+  }
+  WaitStatus wait_for_requested_timestamp(uint64_t ts, std::atomic<bool>& continue_flag, uint64_t& last_seen_ts);
 };
 
 } // namespace utilities

--- a/include/utilities/TimestampEstimatorBase.hpp
+++ b/include/utilities/TimestampEstimatorBase.hpp
@@ -11,9 +11,9 @@
 
 #include <atomic>
 #include <chrono>
+#include <limits>
 
-namespace dunedaq {
-namespace utilities {
+namespace dunedaq::utilities {
 
 /**
  * @brief TimestampEstimatorBase is the base class for timestamp-based
@@ -23,11 +23,11 @@ namespace utilities {
 class TimestampEstimatorBase
 {
 public:
-  static constexpr uint64_t s_invalid_ts = std::numeric_limits<uint64_t>::max();
+  static constexpr uint64_t s_invalid_ts = std::numeric_limits<uint64_t>::max(); // NOLINT(build/unsigned)
 
   virtual ~TimestampEstimatorBase() = default;
-  virtual uint64_t get_timestamp_estimate() const = 0;
-  virtual std::chrono::microseconds get_wait_estimate(uint64_t ts) const = 0;
+  virtual uint64_t get_timestamp_estimate() const = 0;                        // NOLINT(build/unsigned)
+  virtual std::chrono::microseconds get_wait_estimate(uint64_t ts) const = 0; // NOLINT(build/unsigned)
 
   enum WaitStatus
   {
@@ -44,10 +44,11 @@ public:
   */
   WaitStatus wait_for_valid_timestamp(std::atomic<bool>& continue_flag)
   {
-    uint64_t ts_discard = s_invalid_ts;
+    uint64_t ts_discard = s_invalid_ts; // NOLINT(build/unsigned)
     return wait_for_valid_timestamp(continue_flag, ts_discard);
   }
-  WaitStatus wait_for_valid_timestamp(std::atomic<bool>& continue_flag, uint64_t& last_seen_ts);
+  WaitStatus wait_for_valid_timestamp(std::atomic<bool>& continue_flag,
+                                      uint64_t& last_seen_ts); // NOLINT(build/unsigned)
 
   /**
      Wait for the current timestamp estimate to reach ts, or for
@@ -55,15 +56,16 @@ public:
 
      Returns kFinished if the timestamp became valid, or kInterrupted if continue_flag became false first
   */
-  WaitStatus wait_for_requested_timestamp(uint64_t ts, std::atomic<bool>& continue_flag)
+  WaitStatus wait_for_requested_timestamp(uint64_t ts, std::atomic<bool>& continue_flag) // NOLINT(build/unsigned)
   {
-    uint64_t ts_discard = s_invalid_ts;
+    uint64_t ts_discard = s_invalid_ts; // NOLINT(build/unsigned)
     return wait_for_requested_timestamp(ts, continue_flag, ts_discard);
   }
-  WaitStatus wait_for_requested_timestamp(uint64_t ts, std::atomic<bool>& continue_flag, uint64_t& last_seen_ts);
+  WaitStatus wait_for_requested_timestamp(uint64_t ts, // NOLINT(build/unsigned)
+                                          std::atomic<bool>& continue_flag,
+                                          uint64_t& last_seen_ts); // NOLINT(build/unsigned)
 };
 
-} // namespace utilities
-} // namespace dunedaq
+} // namespace dunedaq::utilities
 
 #endif // UTILITIES_INCLUDE_UTILITIES_TIMESTAMPESTIMATORBASE_HPP_

--- a/include/utilities/TimestampEstimatorSystem.hpp
+++ b/include/utilities/TimestampEstimatorSystem.hpp
@@ -9,11 +9,10 @@
 #ifndef UTILITIES_INCLUDE_UTILITIES_TIMESTAMPESTIMATORSYSTEM_HPP_
 #define UTILITIES_INCLUDE_UTILITIES_TIMESTAMPESTIMATORSYSTEM_HPP_
 
-#include "utilities/TimestampEstimatorBase.hpp"
 #include "utilities/Issues.hpp"
+#include "utilities/TimestampEstimatorBase.hpp"
 
-namespace dunedaq {
-namespace utilities {
+namespace dunedaq::utilities {
 
 /**
  * @brief TimestampEstimatorSystem is an implementation of
@@ -24,15 +23,14 @@ class TimestampEstimatorSystem : public TimestampEstimatorBase
 public:
   explicit TimestampEstimatorSystem(uint64_t clock_frequency_hz); // NOLINT(build/unsigned)
 
-  uint64_t get_timestamp_estimate() const override;
+  uint64_t get_timestamp_estimate() const override; // NOLINT(build/unsigned)
 
-  std::chrono::microseconds get_wait_estimate(uint64_t ts) const override;
+  std::chrono::microseconds get_wait_estimate(uint64_t ts) const override; // NOLINT(build/unsigned)
 
 private:
   uint64_t m_clock_frequency_hz; // NOLINT(build/unsigned)
 };
 
-} // namespace utilities
-} // namespace dunedaq
+} // namespace dunedaq::utilities
 
 #endif // UTILITIES_INCLUDE_UTILITIES_TIMESTAMPESTIMATORSYSTEM_HPP_

--- a/include/utilities/TimestampEstimatorTimeSync.hpp
+++ b/include/utilities/TimestampEstimatorTimeSync.hpp
@@ -4,7 +4,7 @@
  * This is part of the DUNE DAQ Application Framework, copyright 2020.
  * Licensing/copyright details are in the COPYING file that you should have
  * received with this code.
- * 
+ *
  * This is an implementation of TimestampEstimatorBase that uses timestamps
  * from the TimeSync messages received by the application
  */
@@ -12,15 +12,21 @@
 #ifndef UTILITIES_INCLUDE_UTILITIES_TIMESTAMPESTIMATORTIMESYNC_HPP_
 #define UTILITIES_INCLUDE_UTILITIES_TIMESTAMPESTIMATORTIMESYNC_HPP_
 
-#include "utilities/TimestampEstimatorBase.hpp"
 #include "utilities/Issues.hpp"
+#include "utilities/TimestampEstimatorBase.hpp"
 
 #include <atomic>
 #include <memory>
 #include <mutex>
 
-namespace dunedaq {
-namespace utilities {
+namespace dunedaq::utilities {
+
+enum
+{
+  TLVL_TIME_SYNC_PROPERTIES = 17,
+  TLVL_TIME_SYNC_NOTES = 18,
+  TLVL_TIME_SYNC_NEW_ESTIMATE = 19,
+};
 
 /**
  * @brief TimestampEstimatorTimeSync is an implementation of
@@ -30,43 +36,42 @@ namespace utilities {
 class TimestampEstimatorTimeSync : public TimestampEstimatorBase
 {
 public:
-  TimestampEstimatorTimeSync(uint32_t run_number, uint64_t clock_frequency_hz);
+  TimestampEstimatorTimeSync(uint32_t run_number, uint64_t clock_frequency_hz); // NOLINT(build/unsigned)
 
   explicit TimestampEstimatorTimeSync(uint64_t clock_frequency_hz); // NOLINT(build/unsigned)
 
   virtual ~TimestampEstimatorTimeSync();
 
-  uint64_t get_timestamp_estimate() const override;
+  uint64_t get_timestamp_estimate() const override; // NOLINT(build/unsigned)
 
-  std::chrono::microseconds get_wait_estimate(uint64_t ts) const override;
+  std::chrono::microseconds get_wait_estimate(uint64_t ts) const override; // NOLINT(build/unsigned)
 
-  void add_timestamp_datapoint(uint64_t daq_time, uint64_t system_time);
+  void add_timestamp_datapoint(uint64_t daq_time, uint64_t system_time); // NOLINT(build/unsigned)
 
-  template <class T>
+  template<class T>
   void timesync_callback(const T& tsync);
 
-  uint64_t get_received_timesync_count() const { return m_received_timesync_count.load(); }
-private:
+  uint64_t get_received_timesync_count() const { return m_received_timesync_count.load(); } // NOLINT(build/unsigned)
 
-  struct TimeSyncPoint {
-    uint64_t daq_time{s_invalid_ts};
+private:
+  struct TimeSyncPoint
+  {
+    uint64_t daq_time{ s_invalid_ts }; // NOLINT(build/unsigned)
     std::chrono::time_point<std::chrono::steady_clock> system_time;
   };
-  
+
   std::atomic<TimeSyncPoint> m_current_timestamp_estimate;
 
-
-  uint64_t m_clock_frequency_hz; // NOLINT(build/unsigned)
-  uint64_t m_most_recent_daq_time{s_invalid_ts};
-  uint64_t m_most_recent_system_time;
+  uint64_t m_clock_frequency_hz;                   // NOLINT(build/unsigned)
+  uint64_t m_most_recent_daq_time{ s_invalid_ts }; // NOLINT(build/unsigned)
+  uint64_t m_most_recent_system_time;              // NOLINT(build/unsigned)
   std::mutex m_datapoint_mutex;
-  uint32_t m_run_number {0};
+  uint32_t m_run_number{ 0 };                      // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_received_timesync_count; // NOLINT(build/unsigned)
-  uint32_t m_current_process_id;
+  uint32_t m_current_process_id;                   // NOLINT(build/unsigned)
 };
 
-} // namespace utilities
-} // namespace dunedaq
+} // namespace dunedaq::utilities
 
 #include "detail/TimestampEstimatorTimeSync.hxx"
 

--- a/include/utilities/TimestampEstimatorTimeSync.hpp
+++ b/include/utilities/TimestampEstimatorTimeSync.hpp
@@ -1,5 +1,5 @@
 /**
- * @file TimestampEstimator.hpp TimestampEstimator Class
+ * @file TimestampEstimatorTimeSync.hpp TimestampEstimatorTimeSync Class
  *
  * This is part of the DUNE DAQ Application Framework, copyright 2020.
  * Licensing/copyright details are in the COPYING file that you should have

--- a/include/utilities/TimestampEstimatorTimeSync.hpp
+++ b/include/utilities/TimestampEstimatorTimeSync.hpp
@@ -4,10 +4,13 @@
  * This is part of the DUNE DAQ Application Framework, copyright 2020.
  * Licensing/copyright details are in the COPYING file that you should have
  * received with this code.
+ * 
+ * This is an implementation of TimestampEstimatorBase that uses timestamps
+ * from the TimeSync messages received by the application
  */
 
-#ifndef UTILITIES_INCLUDE_UTILITIES_TIMESTAMPESTIMATOR_HPP_
-#define UTILITIES_INCLUDE_UTILITIES_TIMESTAMPESTIMATOR_HPP_
+#ifndef UTILITIES_INCLUDE_UTILITIES_TIMESTAMPESTIMATORTIMESYNC_HPP_
+#define UTILITIES_INCLUDE_UTILITIES_TIMESTAMPESTIMATORTIMESYNC_HPP_
 
 #include "utilities/TimestampEstimatorBase.hpp"
 #include "utilities/Issues.hpp"
@@ -20,18 +23,18 @@ namespace dunedaq {
 namespace utilities {
 
 /**
- * @brief TimestampEstimator is an implementation of
+ * @brief TimestampEstimatorTimeSync is an implementation of
  * TimestampEstimatorBase that uses TimeSync messages from an input
  * queue to estimate the current timestamp
  **/
-class TimestampEstimator : public TimestampEstimatorBase
+class TimestampEstimatorTimeSync : public TimestampEstimatorBase
 {
 public:
-  TimestampEstimator(uint32_t run_number, uint64_t clock_frequency_hz);
+  TimestampEstimatorTimeSync(uint32_t run_number, uint64_t clock_frequency_hz);
 
-  explicit TimestampEstimator(uint64_t clock_frequency_hz); // NOLINT(build/unsigned)
+  explicit TimestampEstimatorTimeSync(uint64_t clock_frequency_hz); // NOLINT(build/unsigned)
 
-  virtual ~TimestampEstimator();
+  virtual ~TimestampEstimatorTimeSync();
 
   uint64_t get_timestamp_estimate() const override;
 
@@ -46,7 +49,7 @@ public:
 private:
 
   struct TimeSyncPoint {
-    uint64_t daq_time;
+    uint64_t daq_time{s_invalid_ts};
     std::chrono::time_point<std::chrono::steady_clock> system_time;
   };
   
@@ -54,7 +57,7 @@ private:
 
 
   uint64_t m_clock_frequency_hz; // NOLINT(build/unsigned)
-  uint64_t m_most_recent_daq_time;
+  uint64_t m_most_recent_daq_time{s_invalid_ts};
   uint64_t m_most_recent_system_time;
   std::mutex m_datapoint_mutex;
   uint32_t m_run_number {0};
@@ -65,6 +68,6 @@ private:
 } // namespace utilities
 } // namespace dunedaq
 
-#include "detail/TimestampEstimator.hxx"
+#include "detail/TimestampEstimatorTimeSync.hxx"
 
-#endif // UTILITIES_INCLUDE_UTILITIES_TIMESTAMPESTIMATOR_HPP_
+#endif // UTILITIES_INCLUDE_UTILITIES_TIMESTAMPESTIMATORTIMESYNC_HPP_

--- a/include/utilities/detail/TimestampEstimatorTimeSync.hxx
+++ b/include/utilities/detail/TimestampEstimatorTimeSync.hxx
@@ -4,7 +4,7 @@ namespace dunedaq {
 namespace utilities {
 
 template <class T>
-void TimestampEstimator::timesync_callback(const T& tsync)
+void TimestampEstimatorTimeSync::timesync_callback(const T& tsync)
 {
   ++m_received_timesync_count;
   TLOG_DEBUG(TLVL_TIME_SYNC_PROPERTIES) << "Got a TimeSync run=" << tsync.run_number << " local run=" << m_run_number 

--- a/include/utilities/detail/TimestampEstimatorTimeSync.hxx
+++ b/include/utilities/detail/TimestampEstimatorTimeSync.hxx
@@ -1,22 +1,20 @@
 #include "logging/Logging.hpp"
 
-namespace dunedaq {
-namespace utilities {
+namespace dunedaq::utilities {
 
-template <class T>
-void TimestampEstimatorTimeSync::timesync_callback(const T& tsync)
+template<class T>
+void
+TimestampEstimatorTimeSync::timesync_callback(const T& tsync)
 {
   ++m_received_timesync_count;
-  TLOG_DEBUG(TLVL_TIME_SYNC_PROPERTIES) << "Got a TimeSync run=" << tsync.run_number << " local run=" << m_run_number 
-                                        << " seqno=" << tsync.sequence_number
-                                        << " source_pid=" << tsync.source_pid;
+  TLOG_DEBUG(TLVL_TIME_SYNC_PROPERTIES) << "Got a TimeSync run=" << tsync.run_number << " local run=" << m_run_number
+                                        << " seqno=" << tsync.sequence_number << " source_pid=" << tsync.source_pid;
   if (tsync.run_number == m_run_number && tsync.source_pid != m_current_process_id) {
     add_timestamp_datapoint(tsync.daq_time, tsync.system_time);
   } else {
-    TLOG_DEBUG(0) << "Discarded TimeSync message from run " << tsync.run_number << " during run "
-                  << m_run_number << " with pid " << tsync.source_pid << " and timestamp " << tsync.daq_time;
+    TLOG_DEBUG(0) << "Discarded TimeSync message from run " << tsync.run_number << " during run " << m_run_number
+                  << " with pid " << tsync.source_pid << " and timestamp " << tsync.daq_time;
   }
 }
 
-}
-}
+} // namespace dunedaq::utilities

--- a/src/TimestampEstimatorBase.cpp
+++ b/src/TimestampEstimatorBase.cpp
@@ -10,8 +10,7 @@
 
 #include <thread>
 
-namespace dunedaq {
-namespace utilities {
+namespace dunedaq::utilities {
 
 /**
  * @brief Waits for a valid timestamp to become available.  Returns a status value that
@@ -25,7 +24,7 @@ namespace utilities {
  * @return kFinished if a valid timestamp is available or kInterrupted if one is not
  */
 TimestampEstimatorBase::WaitStatus
-TimestampEstimatorBase::wait_for_valid_timestamp(std::atomic<bool>& continue_flag, uint64_t& last_seen_ts)
+TimestampEstimatorBase::wait_for_valid_timestamp(std::atomic<bool>& continue_flag, uint64_t& last_seen_ts) // NOLINT
 {
   last_seen_ts = s_invalid_ts;
   auto sleep_time = std::chrono::microseconds(1);
@@ -39,17 +38,18 @@ TimestampEstimatorBase::wait_for_valid_timestamp(std::atomic<bool>& continue_fla
 
   // 27-May-2025, KAB: modified this return statement so that the return code is based on whether a
   // valid timestamp is available (instead of whether the caller asked the method to wait or not)
-  return (last_seen_ts != s_invalid_ts) ? TimestampEstimatorBase::kFinished
-                                                    : TimestampEstimatorBase::kInterrupted;
+  return (last_seen_ts != s_invalid_ts) ? TimestampEstimatorBase::kFinished : TimestampEstimatorBase::kInterrupted;
 }
 
 TimestampEstimatorBase::WaitStatus
-TimestampEstimatorBase::wait_for_requested_timestamp(uint64_t ts, std::atomic<bool>& continue_flag, uint64_t& last_seen_ts)
+TimestampEstimatorBase::wait_for_requested_timestamp(uint64_t ts, // NOLINT(build/unsigned)
+                                                     std::atomic<bool>& continue_flag,
+                                                     uint64_t& last_seen_ts) // NOLINT(build/unsigned)
 {
   last_seen_ts = s_invalid_ts;
   auto get_sleep_time = [this, ts]() {
     auto est = get_wait_estimate(ts);
-    auto pest = static_cast<long>(est.count() * 0.8);
+    auto pest = static_cast<std::chrono::microseconds::rep>(static_cast<double>(est.count()) * 0.8);
     if (pest < 1 && est != std::chrono::microseconds(0))
       return std::chrono::microseconds(1);
     return std::chrono::microseconds(pest);
@@ -64,5 +64,4 @@ TimestampEstimatorBase::wait_for_requested_timestamp(uint64_t ts, std::atomic<bo
                                                               : TimestampEstimatorBase::kInterrupted;
 }
 
-} // namespace utilities
-} // namespace dunedaq
+} // namespace dunedaq::utilities

--- a/src/TimestampEstimatorBase.cpp
+++ b/src/TimestampEstimatorBase.cpp
@@ -18,16 +18,19 @@ namespace utilities {
  *        indicates whether a valid timestamp is available or not.
  * @param continue_flag whether to continue waiting until a valid timestamp is available
  *        or return immediately
+ * @param last_seen_ts (Output parameter) the last timestamp seen by the method
  * @details The value of the continue_flag can be changed from true to false externally
  *          to this method, and that will cause the method to exit soon thereafter
  *          (on the order of 10 msec) and return the current status.
  * @return kFinished if a valid timestamp is available or kInterrupted if one is not
  */
 TimestampEstimatorBase::WaitStatus
-TimestampEstimatorBase::wait_for_valid_timestamp(std::atomic<bool>& continue_flag)
+TimestampEstimatorBase::wait_for_valid_timestamp(std::atomic<bool>& continue_flag, uint64_t& last_seen_ts)
 {
+  last_seen_ts = s_invalid_ts;
   auto sleep_time = std::chrono::microseconds(1);
-  while (continue_flag.load() && get_timestamp_estimate() == std::numeric_limits<uint64_t>::max()) {
+  // Always call get_timestamp_estimate at least once
+  while ((last_seen_ts = get_timestamp_estimate()) == s_invalid_ts && continue_flag.load()) {
     std::this_thread::sleep_for(sleep_time);
     if (sleep_time < std::chrono::milliseconds(10)) {
       sleep_time *= 2;
@@ -36,12 +39,14 @@ TimestampEstimatorBase::wait_for_valid_timestamp(std::atomic<bool>& continue_fla
 
   // 27-May-2025, KAB: modified this return statement so that the return code is based on whether a
   // valid timestamp is available (instead of whether the caller asked the method to wait or not)
-  return (get_timestamp_estimate() != std::numeric_limits<uint64_t>::max()) ? TimestampEstimatorBase::kFinished : TimestampEstimatorBase::kInterrupted;
+  return (last_seen_ts != s_invalid_ts) ? TimestampEstimatorBase::kFinished
+                                                    : TimestampEstimatorBase::kInterrupted;
 }
 
 TimestampEstimatorBase::WaitStatus
-TimestampEstimatorBase::wait_for_timestamp(uint64_t ts, std::atomic<bool>& continue_flag)
+TimestampEstimatorBase::wait_for_requested_timestamp(uint64_t ts, std::atomic<bool>& continue_flag, uint64_t& last_seen_ts)
 {
+  last_seen_ts = s_invalid_ts;
   auto get_sleep_time = [this, ts]() {
     auto est = get_wait_estimate(ts);
     auto pest = static_cast<long>(est.count() * 0.8);
@@ -50,13 +55,13 @@ TimestampEstimatorBase::wait_for_timestamp(uint64_t ts, std::atomic<bool>& conti
     return std::chrono::microseconds(pest);
   };
   auto sleep_time = get_sleep_time();
-  while (continue_flag.load() &&
-         (get_timestamp_estimate() < ts || get_timestamp_estimate() == std::numeric_limits<uint64_t>::max())) {
+  // Always call get_timestamp_estimate at least once
+  while (((last_seen_ts = get_timestamp_estimate()) < ts || last_seen_ts == s_invalid_ts) && continue_flag.load()) {
     std::this_thread::sleep_for(sleep_time);
     sleep_time = get_sleep_time();
   }
-
-  return continue_flag.load() ? TimestampEstimatorBase::kFinished : TimestampEstimatorBase::kInterrupted;
+  return (last_seen_ts >= ts && last_seen_ts != s_invalid_ts) ? TimestampEstimatorBase::kFinished
+                                                              : TimestampEstimatorBase::kInterrupted;
 }
 
 } // namespace utilities

--- a/src/TimestampEstimatorSystem.cpp
+++ b/src/TimestampEstimatorSystem.cpp
@@ -12,35 +12,35 @@
 
 #include <chrono>
 
-namespace dunedaq {
-namespace utilities {
+namespace dunedaq::utilities {
 
 TimestampEstimatorSystem::TimestampEstimatorSystem(uint64_t clock_frequency_hz) // NOLINT(build/unsigned)
   : m_clock_frequency_hz(clock_frequency_hz)
 {
   TLOG_DEBUG(0) << "Clock frequency is " << m_clock_frequency_hz
-                << " clock_frequency_hz/1000000.=" << (m_clock_frequency_hz / 1000000.);
+                << " clock_frequency_hz/1000000.=" << (static_cast<double>(m_clock_frequency_hz) / 1000000.);
 }
 
-uint64_t
+uint64_t // NOLINT(build/unsigned)
 TimestampEstimatorSystem::get_timestamp_estimate() const
 {
   auto now = std::chrono::system_clock::now().time_since_epoch();
   auto now_us = std::chrono::duration_cast<std::chrono::microseconds>(now);
-  return (m_clock_frequency_hz / 1000000.) * now_us.count();
+  return static_cast<uint64_t>((static_cast<double>(m_clock_frequency_hz) / 1000000.) * // NOLINT
+                               static_cast<double>(now_us.count()));
 }
 
 std::chrono::microseconds
-TimestampEstimatorSystem::get_wait_estimate(uint64_t ts) const
+TimestampEstimatorSystem::get_wait_estimate(uint64_t ts) const // NOLINT(build/unsigned)
 {
   auto now = std::chrono::system_clock::now().time_since_epoch();
   auto now_us = std::chrono::duration_cast<std::chrono::microseconds>(now);
-  auto then = static_cast<long>(ts * 1000000. / m_clock_frequency_hz);
+  auto then = static_cast<std::chrono::microseconds::rep>(static_cast<double>(ts) * 1000000. /
+                                                          static_cast<double>(m_clock_frequency_hz));
   auto then_us = std::chrono::microseconds(then);
   if (then_us < now_us)
     return std::chrono::microseconds(0);
   return then_us - now_us;
 }
 
-} // namespace utilities
-} // namespace dunedaq
+} // namespace dunedaq::utilities

--- a/src/TimestampEstimatorTimeSync.cpp
+++ b/src/TimestampEstimatorTimeSync.cpp
@@ -16,24 +16,24 @@
 
 #define TRACE_NAME "TimestampEstimatorTimeSync" // NOLINT
 
-namespace dunedaq {
-namespace utilities {
-TimestampEstimatorTimeSync::TimestampEstimatorTimeSync(uint32_t run_number, uint64_t clock_frequency_hz) // NOLINT(build/unsigned)
+namespace dunedaq::utilities {
+
+TimestampEstimatorTimeSync::TimestampEstimatorTimeSync(uint32_t run_number,         // NOLINT(build/unsigned)
+                                                       uint64_t clock_frequency_hz) // NOLINT(build/unsigned)
   : TimestampEstimatorTimeSync(clock_frequency_hz)
 {
   m_run_number = run_number;
 }
 
 TimestampEstimatorTimeSync::TimestampEstimatorTimeSync(uint64_t clock_frequency_hz) // NOLINT(build/unsigned)
-  : m_current_timestamp_estimate(
-      TimeSyncPoint{ s_invalid_ts, std::chrono::time_point<std::chrono::steady_clock>() })
+  : m_current_timestamp_estimate(TimeSyncPoint{ s_invalid_ts, std::chrono::time_point<std::chrono::steady_clock>() })
   , m_clock_frequency_hz(clock_frequency_hz)
   , m_most_recent_daq_time(s_invalid_ts)
   , m_most_recent_system_time(0)
   , m_run_number(0)
   , m_received_timesync_count(0)
 {
-  m_current_process_id = static_cast<uint32_t>(getpid());
+  m_current_process_id = static_cast<uint32_t>(getpid()); // NOLINT(build/unsigned)
 }
 
 TimestampEstimatorTimeSync::~TimestampEstimatorTimeSync() {}
@@ -43,7 +43,7 @@ TimestampEstimatorTimeSync::~TimestampEstimatorTimeSync() {}
  * @return the current estimated timestamp (in units of DUNE Timing System ticks) or
  *         s_invalid_ts if no valid timestamp is currently available
  */
-uint64_t
+uint64_t // NOLINT(build/unsigned)
 TimestampEstimatorTimeSync::get_timestamp_estimate() const
 {
   using namespace std::chrono;
@@ -51,27 +51,30 @@ TimestampEstimatorTimeSync::get_timestamp_estimate() const
   TimeSyncPoint estimate = m_current_timestamp_estimate.load();
   // 27-May-2025, KAB: added check if a valid timestamp is available and, if not, return early
   // with the special value that indicates that none is available.
-  if (estimate.daq_time == s_invalid_ts) {return estimate.daq_time;}
+  if (estimate.daq_time == s_invalid_ts) {
+    return estimate.daq_time;
+  }
 
   auto delta_time_us = duration_cast<microseconds>(steady_clock::now() - estimate.system_time).count();
 
-  const uint64_t new_timestamp = estimate.daq_time + delta_time_us * m_clock_frequency_hz / 1000000;
+  const uint64_t new_timestamp = estimate.daq_time + delta_time_us * m_clock_frequency_hz / 1000000; // NOLINT
 
   return new_timestamp;
 }
 
 std::chrono::microseconds
-TimestampEstimatorTimeSync::get_wait_estimate(uint64_t ts) const
+TimestampEstimatorTimeSync::get_wait_estimate(uint64_t ts) const // NOLINT(build/unsigned)
 {
   auto now = get_timestamp_estimate();
   if (now > ts)
     return std::chrono::microseconds(0);
   auto diff = ts - now;
-  return std::chrono::microseconds(static_cast<long>(diff * 1000000. / m_clock_frequency_hz));
+  return std::chrono::microseconds(static_cast<std::chrono::microseconds::rep>(
+    static_cast<double>(diff) * 1000000. / static_cast<double>(m_clock_frequency_hz)));
 }
 
 void
-TimestampEstimatorTimeSync::add_timestamp_datapoint(uint64_t daq_time, uint64_t system_time)
+TimestampEstimatorTimeSync::add_timestamp_datapoint(uint64_t daq_time, uint64_t system_time) // NOLINT(build/unsigned)
 {
   using namespace std::chrono;
 
@@ -79,7 +82,7 @@ TimestampEstimatorTimeSync::add_timestamp_datapoint(uint64_t daq_time, uint64_t 
 
   // First, update the latest timestamp
   TimeSyncPoint estimate = m_current_timestamp_estimate.load();
-  int64_t diff = estimate.daq_time - daq_time;
+  auto diff = static_cast<int64_t>(estimate.daq_time - daq_time);
   TLOG_DEBUG(TLVL_TIME_SYNC_PROPERTIES) << "Got a TimeSync timestamp = " << daq_time
                                         << ", system time = " << system_time << " when current timestamp estimate was "
                                         << estimate.daq_time << ". diff=" << diff;
@@ -117,10 +120,10 @@ TimestampEstimatorTimeSync::add_timestamp_datapoint(uint64_t daq_time, uint64_t 
 
       // Warn user if current system time is more than 1s ahead of latest TimeSync system time. This could be a sign of
       // an issue, e.g. machine times out of sync
-      if (delta_time > 1e6)
+      if (delta_time > 1'000'000)
         ers::warning(LateTimeSync(ERS_HERE, delta_time));
 
-      const uint64_t new_timestamp = m_most_recent_daq_time + delta_time * m_clock_frequency_hz / 1000000;
+      const uint64_t new_timestamp = m_most_recent_daq_time + delta_time * m_clock_frequency_hz / 1000000; // NOLINT
 
       // Don't ever decrease the timestamp; just wait until enough
       // time passes that we want to increase it
@@ -143,5 +146,4 @@ TimestampEstimatorTimeSync::add_timestamp_datapoint(uint64_t daq_time, uint64_t 
   }
 }
 
-} // namespace utilities
-} // namespace dunedaq
+} // namespace dunedaq::utilities

--- a/src/TimestampEstimatorTimeSync.cpp
+++ b/src/TimestampEstimatorTimeSync.cpp
@@ -1,12 +1,12 @@
 /**
- * @file TimestampEstimator.cpp
+ * @file TimestampEstimatorTimeSync.cpp
  *
  * This is part of the DUNE DAQ Software Suite, copyright 2020.
  * Licensing/copyright details are in the COPYING file that you should have
  * received with this code.
  */
 
-#include "utilities/TimestampEstimator.hpp"
+#include "utilities/TimestampEstimatorTimeSync.hpp"
 #include "utilities/Issues.hpp"
 
 #include "logging/Logging.hpp"
@@ -14,21 +14,21 @@
 #include <memory>
 #include <unistd.h>
 
-#define TRACE_NAME "TimestampEstimator" // NOLINT
+#define TRACE_NAME "TimestampEstimatorTimeSync" // NOLINT
 
 namespace dunedaq {
 namespace utilities {
-TimestampEstimator::TimestampEstimator(uint32_t run_number, uint64_t clock_frequency_hz) // NOLINT(build/unsigned)
-  : TimestampEstimator(clock_frequency_hz)
+TimestampEstimatorTimeSync::TimestampEstimatorTimeSync(uint32_t run_number, uint64_t clock_frequency_hz) // NOLINT(build/unsigned)
+  : TimestampEstimatorTimeSync(clock_frequency_hz)
 {
   m_run_number = run_number;
 }
 
-TimestampEstimator::TimestampEstimator(uint64_t clock_frequency_hz) // NOLINT(build/unsigned)
+TimestampEstimatorTimeSync::TimestampEstimatorTimeSync(uint64_t clock_frequency_hz) // NOLINT(build/unsigned)
   : m_current_timestamp_estimate(
-      TimeSyncPoint{ std::numeric_limits<uint64_t>::max(), std::chrono::time_point<std::chrono::steady_clock>() })
+      TimeSyncPoint{ s_invalid_ts, std::chrono::time_point<std::chrono::steady_clock>() })
   , m_clock_frequency_hz(clock_frequency_hz)
-  , m_most_recent_daq_time(0)
+  , m_most_recent_daq_time(s_invalid_ts)
   , m_most_recent_system_time(0)
   , m_run_number(0)
   , m_received_timesync_count(0)
@@ -36,22 +36,22 @@ TimestampEstimator::TimestampEstimator(uint64_t clock_frequency_hz) // NOLINT(bu
   m_current_process_id = static_cast<uint32_t>(getpid());
 }
 
-TimestampEstimator::~TimestampEstimator() {}
+TimestampEstimatorTimeSync::~TimestampEstimatorTimeSync() {}
 
 /**
  * @brief Returns the current timestamp estimate or a special value if no valid timestamp is available
  * @return the current estimated timestamp (in units of DUNE Timing System ticks) or
- *         std::numeric_limits<uint64_t>::max() if no valid timestamp is currently available
+ *         s_invalid_ts if no valid timestamp is currently available
  */
 uint64_t
-TimestampEstimator::get_timestamp_estimate() const
+TimestampEstimatorTimeSync::get_timestamp_estimate() const
 {
   using namespace std::chrono;
 
   TimeSyncPoint estimate = m_current_timestamp_estimate.load();
   // 27-May-2025, KAB: added check if a valid timestamp is available and, if not, return early
   // with the special value that indicates that none is available.
-  if (estimate.daq_time == std::numeric_limits<uint64_t>::max()) {return estimate.daq_time;}
+  if (estimate.daq_time == s_invalid_ts) {return estimate.daq_time;}
 
   auto delta_time_us = duration_cast<microseconds>(steady_clock::now() - estimate.system_time).count();
 
@@ -61,7 +61,7 @@ TimestampEstimator::get_timestamp_estimate() const
 }
 
 std::chrono::microseconds
-TimestampEstimator::get_wait_estimate(uint64_t ts) const
+TimestampEstimatorTimeSync::get_wait_estimate(uint64_t ts) const
 {
   auto now = get_timestamp_estimate();
   if (now > ts)
@@ -71,7 +71,7 @@ TimestampEstimator::get_wait_estimate(uint64_t ts) const
 }
 
 void
-TimestampEstimator::add_timestamp_datapoint(uint64_t daq_time, uint64_t system_time)
+TimestampEstimatorTimeSync::add_timestamp_datapoint(uint64_t daq_time, uint64_t system_time)
 {
   using namespace std::chrono;
 
@@ -84,12 +84,12 @@ TimestampEstimator::add_timestamp_datapoint(uint64_t daq_time, uint64_t system_t
                                         << ", system time = " << system_time << " when current timestamp estimate was "
                                         << estimate.daq_time << ". diff=" << diff;
 
-  if (m_most_recent_daq_time == std::numeric_limits<uint64_t>::max() || daq_time > m_most_recent_daq_time) {
+  if (m_most_recent_daq_time == s_invalid_ts || daq_time > m_most_recent_daq_time) {
     m_most_recent_daq_time = daq_time;
     m_most_recent_system_time = system_time;
   }
 
-  if (m_most_recent_daq_time != std::numeric_limits<uint64_t>::max()) {
+  if (m_most_recent_daq_time != s_invalid_ts) {
     // Update the current timestamp estimate, based on the most recently-read TimeSync
     using namespace std::chrono;
 
@@ -124,7 +124,7 @@ TimestampEstimator::add_timestamp_datapoint(uint64_t daq_time, uint64_t system_t
 
       // Don't ever decrease the timestamp; just wait until enough
       // time passes that we want to increase it
-      if (estimate.daq_time == std::numeric_limits<uint64_t>::max() || new_timestamp >= estimate.daq_time) {
+      if (estimate.daq_time == s_invalid_ts || new_timestamp >= estimate.daq_time) {
         TLOG_DEBUG(TLVL_TIME_SYNC_NEW_ESTIMATE)
           << "Storing new timestamp estimate of " << new_timestamp << " ticks (..." << std::fixed
           << std::setprecision(8)

--- a/unittest/TimestampEstimatorSystem_test.cxx
+++ b/unittest/TimestampEstimatorSystem_test.cxx
@@ -28,8 +28,7 @@ BOOST_AUTO_TEST_CASE(Basics)
   std::atomic<bool> continue_flag{ true };
   dunedaq::utilities::TimestampEstimatorSystem tes(clock_frequency_hz);
 
-  BOOST_CHECK_EQUAL(tes.wait_for_valid_timestamp(continue_flag),
-                    dunedaq::utilities::TimestampEstimatorBase::kFinished);
+  BOOST_CHECK_EQUAL(tes.wait_for_valid_timestamp(continue_flag), dunedaq::utilities::TimestampEstimatorBase::kFinished);
 
   std::atomic<bool> do_not_continue_flag{ false };
   BOOST_CHECK_EQUAL(tes.wait_for_valid_timestamp(do_not_continue_flag),
@@ -57,14 +56,16 @@ BOOST_AUTO_TEST_CASE(StartupBehavior)
   using namespace std::chrono_literals;
 
   const uint64_t clock_frequency_hz = 62'500'000; // NOLINT(build/unsigned)
+  const double clock_frequency_Mhz = 62.5;
 
   utilities::TimestampEstimatorSystem te(clock_frequency_hz);
 
-  uint64_t system_time_start =
+  auto system_time_start =
     static_cast<uint64_t>(duration_cast<microseconds>(system_clock::now().time_since_epoch()).count()); // NOLINT
-  uint64_t steady_time_start =
+  auto steady_time_start =
     static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count()); // NOLINT
-  uint64_t daq_time_start = (clock_frequency_hz / 1000000.) * system_time_start;
+  auto daq_time_start =
+    static_cast<uint64_t>((clock_frequency_Mhz) * static_cast<double>(system_time_start)); // NOLINT(build/unsigned)
 
   std::atomic<bool> do_not_continue_flag{ false };
   std::atomic<bool> do_continue_flag{ true };
@@ -84,12 +85,11 @@ BOOST_AUTO_TEST_CASE(StartupBehavior)
   // TimestampEstimatorSystem always provides valid timestamps
   std::this_thread::sleep_for(100ms);
   BOOST_CHECK_EQUAL(thread_has_finished, true);
-  
+
   // TimestampEstimatorSystem always should return kFinished
   BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_not_continue_flag),
                     dunedaq::utilities::TimestampEstimatorBase::kFinished);
   BOOST_CHECK_EQUAL(thread_has_finished, true);
-
 
   // verify that the wait thread has finished and it received the expected return code
   BOOST_CHECK_EQUAL(thread_has_finished, true);
@@ -104,12 +104,12 @@ BOOST_AUTO_TEST_CASE(StartupBehavior)
   for (size_t i = 0; i < 10; ++i) {
 
     std::this_thread::sleep_for(100ms);
-    uint64_t steady_now =
-      static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count());
-    uint64_t te_now = te.get_timestamp_estimate();
-    int64_t steady_diff = (steady_now - steady_time_start);
-    int64_t te_diff = (te_now - daq_time_start);
-    int64_t dd = te_diff - (steady_diff * clock_frequency_hz / 1'000'000);
+    auto steady_now =
+      static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count()); // NOLINT
+    uint64_t te_now = te.get_timestamp_estimate(); // NOLINT(build/unsigned)
+    auto steady_diff = static_cast<int64_t>(steady_now - steady_time_start);
+    auto te_diff = static_cast<int64_t>(te_now - daq_time_start);
+    auto dd = static_cast<int64_t>(te_diff - (steady_diff * clock_frequency_hz / 1'000'000));
 
     BOOST_CHECK_LT(abs(dd), 1'000);
   }
@@ -130,6 +130,5 @@ BOOST_AUTO_TEST_CASE(AdditionalTestIdeas)
   // non-standard clock frequency
   // bursts and delays
 }
-
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/TimestampEstimatorSystem_test.cxx
+++ b/unittest/TimestampEstimatorSystem_test.cxx
@@ -16,6 +16,9 @@
 #include "boost/test/unit_test.hpp"
 #include <boost/test/tools/old/interface.hpp>
 #include <chrono>
+#include <future>
+
+using namespace dunedaq;
 
 BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
 
@@ -30,20 +33,103 @@ BOOST_AUTO_TEST_CASE(Basics)
 
   std::atomic<bool> do_not_continue_flag{ false };
   BOOST_CHECK_EQUAL(tes.wait_for_valid_timestamp(do_not_continue_flag),
-                    dunedaq::utilities::TimestampEstimatorBase::kInterrupted);
+                    dunedaq::utilities::TimestampEstimatorBase::kFinished);
 
-  dunedaq::daqdataformats::timestamp_t ts_now = tes.get_timestamp_estimate();
-  BOOST_CHECK_EQUAL(tes.wait_for_timestamp(ts_now + clock_frequency_hz, continue_flag),
+  auto ts_now = tes.get_timestamp_estimate();
+  BOOST_CHECK_EQUAL(tes.wait_for_requested_timestamp(ts_now + clock_frequency_hz, continue_flag),
                     dunedaq::utilities::TimestampEstimatorBase::kFinished);
 
   ts_now = tes.get_timestamp_estimate();
-  BOOST_CHECK_EQUAL(tes.wait_for_timestamp(ts_now + clock_frequency_hz, do_not_continue_flag),
+  BOOST_CHECK_EQUAL(tes.wait_for_requested_timestamp(ts_now + clock_frequency_hz, do_not_continue_flag),
                     dunedaq::utilities::TimestampEstimatorBase::kInterrupted);
 
   // Check that the timestamp doesn't go backwards
-  dunedaq::daqdataformats::timestamp_t ts1 = tes.get_timestamp_estimate();
-  dunedaq::daqdataformats::timestamp_t ts2 = tes.get_timestamp_estimate();
+  auto ts1 = tes.get_timestamp_estimate();
+  auto ts2 = tes.get_timestamp_estimate();
   BOOST_CHECK_GE(ts2, ts1);
 }
+
+// 27-May-2025, KAB: this test case is intended to verify that an instance of
+// the TimestampEstimatorSystem behaves as expected when it first starts up.
+BOOST_AUTO_TEST_CASE(StartupBehavior)
+{
+  using namespace std::chrono;
+  using namespace std::chrono_literals;
+
+  const uint64_t clock_frequency_hz = 62'500'000; // NOLINT(build/unsigned)
+
+  utilities::TimestampEstimatorSystem te(clock_frequency_hz);
+
+  uint64_t system_time_start =
+    static_cast<uint64_t>(duration_cast<microseconds>(system_clock::now().time_since_epoch()).count()); // NOLINT
+  uint64_t steady_time_start =
+    static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count()); // NOLINT
+  uint64_t daq_time_start = (clock_frequency_hz / 1000000.) * system_time_start;
+
+  std::atomic<bool> do_not_continue_flag{ false };
+  std::atomic<bool> do_continue_flag{ true };
+  std::atomic<bool> continue_flag_for_thread{ true };
+  std::atomic<bool> thread_has_finished{ false };
+  std::atomic<utilities::TimestampEstimatorBase::WaitStatus> return_code_from_thread_wait{
+    dunedaq::utilities::TimestampEstimatorBase::kInterrupted
+  };
+
+  // spawn a thread that waits until the TSE can provide a valid timestamp
+  std::function<void()> valid_timestamp_wait_func = [&]() {
+    return_code_from_thread_wait = te.wait_for_valid_timestamp(continue_flag_for_thread);
+    thread_has_finished = true;
+  };
+  auto wait_ftr = std::async(std::launch::async, valid_timestamp_wait_func);
+
+  // TimestampEstimatorSystem always provides valid timestamps
+  std::this_thread::sleep_for(100ms);
+  BOOST_CHECK_EQUAL(thread_has_finished, true);
+  
+  // TimestampEstimatorSystem always should return kFinished
+  BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_not_continue_flag),
+                    dunedaq::utilities::TimestampEstimatorBase::kFinished);
+  BOOST_CHECK_EQUAL(thread_has_finished, true);
+
+
+  // verify that the wait thread has finished and it received the expected return code
+  BOOST_CHECK_EQUAL(thread_has_finished, true);
+  BOOST_CHECK_EQUAL(return_code_from_thread_wait, dunedaq::utilities::TimestampEstimatorBase::kFinished);
+  // if the thread has not finished, tell it to finish now
+  if (!thread_has_finished) {
+    continue_flag_for_thread.store(false);
+  }
+
+  // verify that the TSE instance provides valid timestamps and those
+  // timestamp track closely to wallclock time (computer system time)
+  for (size_t i = 0; i < 10; ++i) {
+
+    std::this_thread::sleep_for(100ms);
+    uint64_t steady_now =
+      static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count());
+    uint64_t te_now = te.get_timestamp_estimate();
+    int64_t steady_diff = (steady_now - steady_time_start);
+    int64_t te_diff = (te_now - daq_time_start);
+    int64_t dd = te_diff - (steady_diff * clock_frequency_hz / 1'000'000);
+
+    BOOST_CHECK_LT(abs(dd), 1'000);
+  }
+
+  // now the TSE instance "wait" method should return immediately with a status
+  // that indicates that it *does* have a valid timestamp, independent of whether
+  // we tell it to wait for a valid timestamp or not
+  BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_not_continue_flag),
+                    dunedaq::utilities::TimestampEstimatorBase::kFinished);
+  BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_continue_flag),
+                    dunedaq::utilities::TimestampEstimatorBase::kFinished);
+}
+
+BOOST_AUTO_TEST_CASE(AdditionalTestIdeas)
+{
+  // slow clock
+  // fast clock
+  // non-standard clock frequency
+  // bursts and delays
+}
+
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/unittest/TimestampEstimatorTimeSync_test.cxx
+++ b/unittest/TimestampEstimatorTimeSync_test.cxx
@@ -25,14 +25,15 @@
 #include <memory>
 #include <string>
 
-struct DummyTimeSync {
-  uint64_t daq_time{ dunedaq::utilities::TimestampEstimatorBase::s_invalid_ts };
+struct DummyTimeSync
+{
+  uint64_t daq_time{ dunedaq::utilities::TimestampEstimatorBase::s_invalid_ts }; // NOLINT(build/unsigned)
   /// The current system time
-  uint64_t system_time{ 0 };
+  uint64_t system_time{ 0 }; // NOLINT(build/unsigned)
   /// Sequence Number of this message, for debugging
   uint64_t sequence_number{ 0 }; // NOLINT(build/unsigned)
   /// Run number at time of creation
-  uint32_t run_number{ 0 };
+  uint32_t run_number{ 0 }; // NOLINT(build/unsigned)
   /// PID of the creating process, for debugging
   uint32_t source_pid{ 0 }; // NOLINT(build/unsigned)
 };
@@ -53,7 +54,7 @@ BOOST_AUTO_TEST_SUITE(BOOST_TEST_MODULE)
 //     iomanager::ConnectionIds_t connections;
 //     connections.emplace_back(
 //       iomanager::ConnectionId{ "dummy", iomanager::ServiceType::kQueue, "TimeSync", "queue://kFollyMPMCQueue:100" });
-    
+
 //     get_iomanager()->configure(connections);
 //   }
 
@@ -70,13 +71,16 @@ BOOST_AUTO_TEST_CASE(Basics)
   using namespace std::chrono_literals;
 
   const uint64_t clock_frequency_hz = 62'500'000; // NOLINT(build/unsigned)
+  const double clock_frequency_Mhz = 62.5;
 
-  const uint32_t run_num = 5;
+  const uint32_t run_num = 5; // NOLINT(build/unsigned)
   utilities::TimestampEstimatorTimeSync te(run_num, clock_frequency_hz);
 
-  uint64_t daq_time_start = 1'000'000;
-  uint64_t system_time_start = static_cast<uint64_t>(duration_cast<microseconds>(system_clock::now().time_since_epoch()).count()); // NOLINT
-  uint64_t steady_time_start = static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count()); // NOLINT
+  uint64_t daq_time_start = 1'000'000; // NOLINT(build/unsigned)
+  auto system_time_start =
+    static_cast<uint64_t>(duration_cast<microseconds>(system_clock::now().time_since_epoch()).count()); // NOLINT
+  auto steady_time_start =
+    static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count()); // NOLINT
 
   DummyTimeSync ts;
   ts.daq_time = daq_time_start;
@@ -87,17 +91,17 @@ BOOST_AUTO_TEST_CASE(Basics)
 
   te.timesync_callback(ts);
 
-  for( size_t i=0; i<100; ++i) {
+  for (size_t i = 0; i < 100; ++i) {
 
     std::this_thread::sleep_for(10ms);
-    uint64_t steady_now = static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count());
-    uint64_t te_now = te.get_timestamp_estimate();
-    int64_t steady_diff = (steady_now - steady_time_start);
-    int64_t te_diff = (te_now-daq_time_start);
-    int64_t dd = te_diff-(steady_diff*clock_frequency_hz/1'000'000);
+    auto steady_now =
+      static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count()); // NOLINT
+    uint64_t te_now = te.get_timestamp_estimate(); // NOLINT(build/unsigned)
+    auto steady_diff = static_cast<double>(steady_now - steady_time_start);
+    auto te_diff = static_cast<double>(te_now - daq_time_start);
+    auto dd = static_cast<int64_t>(te_diff - (steady_diff * clock_frequency_Mhz));
 
     BOOST_CHECK_LT(abs(dd), 1'000);
-
   }
 }
 
@@ -109,13 +113,16 @@ BOOST_AUTO_TEST_CASE(StartupBehavior)
   using namespace std::chrono_literals;
 
   const uint64_t clock_frequency_hz = 62'500'000; // NOLINT(build/unsigned)
+  const double clock_frequency_Mhz = 62.5;
 
-  const uint32_t run_num = 5;
+  const uint32_t run_num = 5; // NOLINT(build/unsigned)
   utilities::TimestampEstimatorTimeSync te(run_num, clock_frequency_hz);
 
-  uint64_t daq_time_start = 1'000'000;
-  uint64_t system_time_start = static_cast<uint64_t>(duration_cast<microseconds>(system_clock::now().time_since_epoch()).count()); // NOLINT
-  uint64_t steady_time_start = static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count()); // NOLINT
+  uint64_t daq_time_start = 1'000'000; // NOLINT(build/unsigned)
+  auto system_time_start =
+    static_cast<uint64_t>(duration_cast<microseconds>(system_clock::now().time_since_epoch()).count()); // NOLINT
+  auto steady_time_start =
+    static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count()); // NOLINT
 
   // create a dummy TimeSync message for later use
   DummyTimeSync ts;
@@ -129,7 +136,9 @@ BOOST_AUTO_TEST_CASE(StartupBehavior)
   std::atomic<bool> do_continue_flag{ true };
   std::atomic<bool> continue_flag_for_thread{ true };
   std::atomic<bool> thread_has_finished{ false };
-  std::atomic<utilities::TimestampEstimatorBase::WaitStatus> return_code_from_thread_wait{ utilities::TimestampEstimatorBase::kInterrupted };
+  std::atomic<utilities::TimestampEstimatorBase::WaitStatus> return_code_from_thread_wait{
+    utilities::TimestampEstimatorBase::kInterrupted
+  };
 
   // spawn a thread that waits until the TSE can provide a valid timestamp
   std::function<void()> valid_timestamp_wait_func = [&]() {
@@ -142,22 +151,20 @@ BOOST_AUTO_TEST_CASE(StartupBehavior)
   // a special value that indicates that it can't yet provide a valid timestamp
   // when we ask it for the current timestamp estimate.
   // Also, verify that the wait thread is still waiting.
-  for( size_t i=0; i<10; ++i) {
+  for (size_t i = 0; i < 10; ++i) {
 
     std::this_thread::sleep_for(100ms);
-    uint64_t te_now = te.get_timestamp_estimate();
+    uint64_t te_now = te.get_timestamp_estimate(); // NOLINT(build/unsigned)
     BOOST_CHECK_EQUAL(te_now, utilities::TimestampEstimatorBase::s_invalid_ts);
 
     BOOST_CHECK_EQUAL(thread_has_finished, false);
-
   }
 
   // if we ask the TSE if it has a valid timestamp, and we tell it that it doesn't
   // need to wait until it gets one, AND the TSE instance has not yet received
   // a TimeSync message, it should return immediately and tell us that it is returning
   // without being able to provide a valid timestamp (kInterrupted).
-  BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_not_continue_flag),
-                    utilities::TimestampEstimatorBase::kInterrupted);
+  BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_not_continue_flag), utilities::TimestampEstimatorBase::kInterrupted);
   BOOST_CHECK_EQUAL(thread_has_finished, false);
 
   // pass a TimeSync message into the TSE instance
@@ -168,31 +175,30 @@ BOOST_AUTO_TEST_CASE(StartupBehavior)
   BOOST_CHECK_EQUAL(thread_has_finished, true);
   BOOST_CHECK_EQUAL(return_code_from_thread_wait, utilities::TimestampEstimatorBase::kFinished);
   // if the thread has not finished, tell it to finish now
-  if (! thread_has_finished) {continue_flag_for_thread.store(false);}
+  if (!thread_has_finished) {
+    continue_flag_for_thread.store(false);
+  }
 
   // verify that the TSE instance now provides valid timestamps and those
   // timestamp track closely to wallclock time (computer system time)
-  for( size_t i=0; i<10; ++i) {
+  for (size_t i = 0; i < 10; ++i) {
 
     std::this_thread::sleep_for(100ms);
-    uint64_t steady_now = static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count());
-    uint64_t te_now = te.get_timestamp_estimate();
-    int64_t steady_diff = (steady_now - steady_time_start);
-    int64_t te_diff = (te_now-daq_time_start);
-    int64_t dd = te_diff-(steady_diff*clock_frequency_hz/1'000'000);
+    auto steady_now =
+      static_cast<uint64_t>(duration_cast<microseconds>(steady_clock::now().time_since_epoch()).count()); // NOLINT
+    auto te_now = te.get_timestamp_estimate();
+    auto steady_diff = static_cast<double>(steady_now - steady_time_start);
+    auto te_diff = static_cast<double>(te_now - daq_time_start);
+    auto dd = static_cast<int64_t>(te_diff - (steady_diff * clock_frequency_Mhz));
 
     BOOST_CHECK_LT(abs(dd), 1'000);
-
   }
 
   // now the TSE instance "wait" method should return immediately with a status
   // that indicates that it *does* have a valid timestamp, independent of whether
   // we tell it to wait for a valid timestamp or not
-  BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_not_continue_flag),
-                    utilities::TimestampEstimatorBase::kFinished);
-  BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_continue_flag),
-                    utilities::TimestampEstimatorBase::kFinished);
-
+  BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_not_continue_flag), utilities::TimestampEstimatorBase::kFinished);
+  BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_continue_flag), utilities::TimestampEstimatorBase::kFinished);
 }
 
 BOOST_AUTO_TEST_CASE(AdditionalTestIdeas)

--- a/unittest/TimestampEstimatorTimeSync_test.cxx
+++ b/unittest/TimestampEstimatorTimeSync_test.cxx
@@ -1,5 +1,5 @@
 /**
- * @file TimestampEstimatorSystem_test.cxx  TimestampEstimatorSystem class Unit Tests
+ * @file TimestampEstimatorTimeSync_test.cxx  TimestampEstimatorTimeSync class Unit Tests
  *
  * This is part of the DUNE DAQ Application Framework, copyright 2020.
  * Licensing/copyright details are in the COPYING file that you should have
@@ -9,12 +9,12 @@
 // #include "iomanager/IOManager.hpp"
 // #include "iomanager/Sender.hpp"
 // #include "iomanager/Receiver.hpp"
-#include "utilities/TimestampEstimator.hpp"
+#include "utilities/TimestampEstimatorTimeSync.hpp"
 
 /**
  * @brief Name of this test module
  */
-#define BOOST_TEST_MODULE TimestampEstimator_test // NOLINT
+#define BOOST_TEST_MODULE TimestampEstimatorTimeSync_test // NOLINT
 
 #include "boost/test/unit_test.hpp"
 
@@ -26,7 +26,7 @@
 #include <string>
 
 struct DummyTimeSync {
-  uint64_t daq_time{ std::numeric_limits<uint64_t>::max() };
+  uint64_t daq_time{ dunedaq::utilities::TimestampEstimatorBase::s_invalid_ts };
   /// The current system time
   uint64_t system_time{ 0 };
   /// Sequence Number of this message, for debugging
@@ -72,7 +72,7 @@ BOOST_AUTO_TEST_CASE(Basics)
   const uint64_t clock_frequency_hz = 62'500'000; // NOLINT(build/unsigned)
 
   const uint32_t run_num = 5;
-  utilities::TimestampEstimator te(run_num, clock_frequency_hz);
+  utilities::TimestampEstimatorTimeSync te(run_num, clock_frequency_hz);
 
   uint64_t daq_time_start = 1'000'000;
   uint64_t system_time_start = static_cast<uint64_t>(duration_cast<microseconds>(system_clock::now().time_since_epoch()).count()); // NOLINT
@@ -102,7 +102,7 @@ BOOST_AUTO_TEST_CASE(Basics)
 }
 
 // 27-May-2025, KAB: this test case is intended to verify that an instance of
-// the TimestampEstimator behaves as expected when it first starts up.
+// the TimestampEstimatorTimeSync behaves as expected when it first starts up.
 BOOST_AUTO_TEST_CASE(StartupBehavior)
 {
   using namespace std::chrono;
@@ -111,7 +111,7 @@ BOOST_AUTO_TEST_CASE(StartupBehavior)
   const uint64_t clock_frequency_hz = 62'500'000; // NOLINT(build/unsigned)
 
   const uint32_t run_num = 5;
-  utilities::TimestampEstimator te(run_num, clock_frequency_hz);
+  utilities::TimestampEstimatorTimeSync te(run_num, clock_frequency_hz);
 
   uint64_t daq_time_start = 1'000'000;
   uint64_t system_time_start = static_cast<uint64_t>(duration_cast<microseconds>(system_clock::now().time_since_epoch()).count()); // NOLINT
@@ -129,7 +129,7 @@ BOOST_AUTO_TEST_CASE(StartupBehavior)
   std::atomic<bool> do_continue_flag{ true };
   std::atomic<bool> continue_flag_for_thread{ true };
   std::atomic<bool> thread_has_finished{ false };
-  std::atomic<utilities::TimestampEstimatorBase::WaitStatus> return_code_from_thread_wait{ dunedaq::utilities::TimestampEstimatorBase::kInterrupted };
+  std::atomic<utilities::TimestampEstimatorBase::WaitStatus> return_code_from_thread_wait{ utilities::TimestampEstimatorBase::kInterrupted };
 
   // spawn a thread that waits until the TSE can provide a valid timestamp
   std::function<void()> valid_timestamp_wait_func = [&]() {
@@ -146,7 +146,7 @@ BOOST_AUTO_TEST_CASE(StartupBehavior)
 
     std::this_thread::sleep_for(100ms);
     uint64_t te_now = te.get_timestamp_estimate();
-    BOOST_CHECK_EQUAL(te_now, std::numeric_limits<uint64_t>::max());
+    BOOST_CHECK_EQUAL(te_now, utilities::TimestampEstimatorBase::s_invalid_ts);
 
     BOOST_CHECK_EQUAL(thread_has_finished, false);
 
@@ -157,7 +157,7 @@ BOOST_AUTO_TEST_CASE(StartupBehavior)
   // a TimeSync message, it should return immediately and tell us that it is returning
   // without being able to provide a valid timestamp (kInterrupted).
   BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_not_continue_flag),
-                    dunedaq::utilities::TimestampEstimatorBase::kInterrupted);
+                    utilities::TimestampEstimatorBase::kInterrupted);
   BOOST_CHECK_EQUAL(thread_has_finished, false);
 
   // pass a TimeSync message into the TSE instance
@@ -166,7 +166,7 @@ BOOST_AUTO_TEST_CASE(StartupBehavior)
   // verify that the wait thread has finished and it received the expected return code
   std::this_thread::sleep_for(std::chrono::milliseconds(25));
   BOOST_CHECK_EQUAL(thread_has_finished, true);
-  BOOST_CHECK_EQUAL(return_code_from_thread_wait, dunedaq::utilities::TimestampEstimatorBase::kFinished);
+  BOOST_CHECK_EQUAL(return_code_from_thread_wait, utilities::TimestampEstimatorBase::kFinished);
   // if the thread has not finished, tell it to finish now
   if (! thread_has_finished) {continue_flag_for_thread.store(false);}
 
@@ -189,9 +189,9 @@ BOOST_AUTO_TEST_CASE(StartupBehavior)
   // that indicates that it *does* have a valid timestamp, independent of whether
   // we tell it to wait for a valid timestamp or not
   BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_not_continue_flag),
-                    dunedaq::utilities::TimestampEstimatorBase::kFinished);
+                    utilities::TimestampEstimatorBase::kFinished);
   BOOST_CHECK_EQUAL(te.wait_for_valid_timestamp(do_continue_flag),
-                    dunedaq::utilities::TimestampEstimatorBase::kFinished);
+                    utilities::TimestampEstimatorBase::kFinished);
 
 }
 


### PR DESCRIPTION
This PR implements several suggestions in #35 around the TimestampEstimator family of classes. However, since one of them is renamed, it will also result in coordinated changes in other repositories (TBD).