### PR TITLE
Address review items in the Resolver library

### DIFF
--- a/include/utilities/Resolver.hpp
+++ b/include/utilities/Resolver.hpp
@@ -42,9 +42,9 @@ struct ZmqUri
       return tmp + ":" + port;
     return tmp;
   }
+
+  explicit ZmqUri(std::string connection_string);
 };
-ZmqUri
-parse_connection_string(std::string connection_string);
 
 } // namespace dunedaq::utilities
 

--- a/src/Resolver.cpp
+++ b/src/Resolver.cpp
@@ -19,15 +19,15 @@ dunedaq::utilities::get_ips_from_hostname(std::string hostname)
 
   TLOG_DEBUG(12) << "Name is " << hostname;
 
-  struct addrinfo* result = nullptr;
-  auto s = getaddrinfo(hostname.c_str(), nullptr, nullptr, &result);
+  struct addrinfo* addrinfo = nullptr;
+  auto s = getaddrinfo(hostname.c_str(), nullptr, nullptr, &addrinfo);
 
   if (s != 0) {
     ers::error(NameNotFound(ERS_HERE, hostname, std::string(gai_strerror(s))));
     return output;
   }
 
-  for (auto rp = result; rp != nullptr; rp = rp->ai_next) {
+  for (auto rp = addrinfo; rp != nullptr; rp = rp->ai_next) {
     char hbuf[NI_MAXHOST], sbuf[NI_MAXSERV]; // NOLINT
 
     // Let's skip all the IPv6 here
@@ -35,21 +35,21 @@ dunedaq::utilities::get_ips_from_hostname(std::string hostname)
       continue;
 
     getnameinfo(rp->ai_addr, rp->ai_addrlen, hbuf, sizeof(hbuf), sbuf, sizeof(sbuf), NI_NUMERICHOST | NI_NUMERICSERV);
-    auto result = std::string(hbuf);
+    auto ipaddr = std::string(hbuf);
     bool duplicate = false;
-    for (auto& res : output) {
-      if (res == result) {
+    for (auto& ip : output) {
+      if (ip == ipaddr) {
         duplicate = true;
         break;
       }
     }
     if (!duplicate) {
-      TLOG_DEBUG(13) << "Found address " << result << " for hostname " << hostname;
-      output.push_back(result);
+      TLOG_DEBUG(13) << "Found address " << ipaddr << " for hostname " << hostname;
+      output.push_back(ipaddr);
     }
   }
 
-  freeaddrinfo(result);
+  freeaddrinfo(addrinfo);
 
   return output;
 }
@@ -57,7 +57,7 @@ dunedaq::utilities::get_ips_from_hostname(std::string hostname)
 std::vector<std::string>
 dunedaq::utilities::resolve_uri_hostname(std::string connection_string)
 {
-  auto uri = parse_connection_string(connection_string);
+  auto uri = ZmqUri(connection_string);
 
   if (uri.scheme == "tcp") {
     auto output = get_ips_from_hostname(uri.host);
@@ -71,24 +71,19 @@ dunedaq::utilities::resolve_uri_hostname(std::string connection_string)
   }
 }
 
-dunedaq::utilities::ZmqUri
-dunedaq::utilities::parse_connection_string(std::string connection_string)
+// ZMQ URIs are formatted as follows: tcp://{host}:{port}
+dunedaq::utilities::ZmqUri::ZmqUri(std::string connection_string)
 {
-  // ZMQ URIs are formatted as follows: tcp://{host}:{port}
-  ZmqUri output;
-
   if (connection_string.find("://") == std::string::npos) {
     throw InvalidUri(ERS_HERE, connection_string);
   }
 
-  output.scheme = connection_string.substr(0, connection_string.find("://"));
+  scheme = connection_string.substr(0, connection_string.find("://"));
   connection_string = connection_string.substr(connection_string.find("://") + 3);
 
   if (connection_string.find(":") != std::string::npos) {
-    output.port = connection_string.substr(connection_string.find(":") + 1);
+    port = connection_string.substr(connection_string.find(":") + 1);
     connection_string = connection_string.substr(0, connection_string.find(":"));
   }
-  output.host = connection_string;
-
-  return output;
+  host = connection_string;
 }

--- a/src/Resolver.cpp
+++ b/src/Resolver.cpp
@@ -57,7 +57,7 @@ dunedaq::utilities::get_ips_from_hostname(std::string hostname)
 std::vector<std::string>
 dunedaq::utilities::resolve_uri_hostname(std::string connection_string)
 {
-  auto uri = ZmqUri(connection_string);
+  ZmqUri uri(connection_string);
 
   if (uri.scheme == "tcp") {
     auto output = get_ips_from_hostname(uri.host);


### PR DESCRIPTION
(Includes changes in #49)

Address the issues in the Resolver.hpp/cpp library identified in #35.

Reactive PR will be opened in `iomanager`.