### PR TITLE
Updated TimestampEstimatorTimeSync to react to the change in the Time…

### DIFF
--- a/include/utilities/TimestampEstimatorTimeSync.hpp
+++ b/include/utilities/TimestampEstimatorTimeSync.hpp
@@ -68,7 +68,6 @@ private:
   std::mutex m_datapoint_mutex;
   uint32_t m_run_number{ 0 };                      // NOLINT(build/unsigned)
   std::atomic<uint64_t> m_received_timesync_count; // NOLINT(build/unsigned)
-  uint32_t m_current_process_id;                   // NOLINT(build/unsigned)
 };
 
 } // namespace dunedaq::utilities

--- a/include/utilities/detail/TimestampEstimatorTimeSync.hxx
+++ b/include/utilities/detail/TimestampEstimatorTimeSync.hxx
@@ -8,12 +8,12 @@ TimestampEstimatorTimeSync::timesync_callback(const T& tsync)
 {
   ++m_received_timesync_count;
   TLOG_DEBUG(TLVL_TIME_SYNC_PROPERTIES) << "Got a TimeSync run=" << tsync.run_number << " local run=" << m_run_number
-                                        << " seqno=" << tsync.sequence_number << " source_pid=" << tsync.source_pid;
-  if (tsync.run_number == m_run_number && tsync.source_pid != m_current_process_id) {
+                                        << " seqno=" << tsync.sequence_number << " source_id=" << tsync.source_id;
+  if (tsync.run_number == m_run_number) {
     add_timestamp_datapoint(tsync.daq_time, tsync.system_time);
   } else {
     TLOG_DEBUG(0) << "Discarded TimeSync message from run " << tsync.run_number << " during run " << m_run_number
-                  << " with pid " << tsync.source_pid << " and timestamp " << tsync.daq_time;
+                  << " with source_id " << tsync.source_id << " and timestamp " << tsync.daq_time;
   }
 }
 

--- a/src/TimestampEstimatorTimeSync.cpp
+++ b/src/TimestampEstimatorTimeSync.cpp
@@ -33,7 +33,6 @@ TimestampEstimatorTimeSync::TimestampEstimatorTimeSync(uint64_t clock_frequency_
   , m_run_number(0)
   , m_received_timesync_count(0)
 {
-  m_current_process_id = static_cast<uint32_t>(getpid()); // NOLINT(build/unsigned)
 }
 
 TimestampEstimatorTimeSync::~TimestampEstimatorTimeSync() {}

--- a/unittest/TimestampEstimatorTimeSync_test.cxx
+++ b/unittest/TimestampEstimatorTimeSync_test.cxx
@@ -34,8 +34,8 @@ struct DummyTimeSync
   uint64_t sequence_number{ 0 }; // NOLINT(build/unsigned)
   /// Run number at time of creation
   uint32_t run_number{ 0 }; // NOLINT(build/unsigned)
-  /// PID of the creating process, for debugging
-  uint32_t source_pid{ 0 }; // NOLINT(build/unsigned)
+  /// SourceID::id of the creating process, for debugging
+  uint32_t source_id{ 0 }; // NOLINT(build/unsigned)
 };
 
 using namespace dunedaq;
@@ -87,7 +87,7 @@ BOOST_AUTO_TEST_CASE(Basics)
   ts.system_time = system_time_start;
   ts.sequence_number = 1;
   ts.run_number = run_num;
-  ts.source_pid = 12345;
+  ts.source_id = 12345;
 
   te.timesync_callback(ts);
 
@@ -130,7 +130,7 @@ BOOST_AUTO_TEST_CASE(StartupBehavior)
   ts.system_time = system_time_start;
   ts.sequence_number = 1;
   ts.run_number = run_num;
-  ts.source_pid = 12345;
+  ts.source_id = 12345;
 
   std::atomic<bool> do_not_continue_flag{ false };
   std::atomic<bool> do_continue_flag{ true };


### PR DESCRIPTION
…Sync message to have a SourceID.id field instead of a Linux process ID.  Also, removed the validation of the source of TimeSync messages, in favor of having validation of system configurations.

## Description

These changes are part of a set of changes that are described in DUNE-DAQ/daq-deliverables#188.  Overall, the goal is to eliminate the use of Linux process IDs in identifying the source of TimeSync messages (to avoid problems with their use in certain environments) and use DAQ SourceID information instead.

Please see the `daq-deliverables` Issue for more details, including the full set of repositories that have correlated changes.

## Testing Suggestions

Please see DUNE-DAQ/daq-deliverables#188.
