### PR TITLE
Utilities for connecting via multiple interfaces

### DIFF
--- a/include/utilities/ZmqUri.hpp
+++ b/include/utilities/ZmqUri.hpp
@@ -21,15 +21,12 @@ namespace dunedaq::utilities {
 struct ZmqUri
 {
   std::string scheme{ "" };
+  std::string endpoint_host{ "" };
+  std::string endpoint_port{ "" };
   std::string host{ "" };
   std::string port{ "" };
-  std::string to_string()
-  {
-    auto tmp = scheme + "://" + host;
-    if (port != "")
-      return tmp + ":" + port;
-    return tmp;
-  }
+
+  std::string to_string();
 
   explicit ZmqUri(std::string connection_string);
 

--- a/include/utilities/get_ips.hpp
+++ b/include/utilities/get_ips.hpp
@@ -14,11 +14,13 @@
 #include "logging/Logging.hpp"
 #include "utilities/Issues.hpp"
 
+#include <arpa/inet.h>
 #include <arpa/nameser.h>
 #include <ifaddrs.h>
 #include <netdb.h>
 #include <netinet/in.h>
 #include <resolv.h>
+#include <sys/socket.h> // inet_aton
 #include <sys/types.h>
 
 #include <cerrno> // NOLINT(runtime/output_format
@@ -110,6 +112,39 @@ get_interface_ip(std::string eth_device_name, bool throw_if_missing = false)
   }
 
   return ipaddr;
+}
+
+inline std::vector<std::string>
+get_ips_matching_network(std::string ip_to_match)
+{
+  std::vector<std::string> output;
+  struct in_addr target_addr;
+  inet_aton(ip_to_match.c_str(), &target_addr);
+
+  struct ifaddrs* ifaddr = nullptr;
+  getifaddrs(&ifaddr);
+
+  for (auto ifa = ifaddr; ifa != nullptr; ifa = ifa->ifa_next) {
+    if (ifa->ifa_addr == nullptr || ifa->ifa_addr->sa_family != AF_INET) {
+      continue;
+    }
+
+    auto if_addr = reinterpret_cast<struct sockaddr_in*>(ifa->ifa_addr)->sin_addr.s_addr;
+    auto netmask = reinterpret_cast<struct sockaddr_in*>(ifa->ifa_netmask)->sin_addr.s_addr;
+    // Check if target IP is in this interface's address space
+    if ((if_addr & netmask) == (target_addr.s_addr & netmask)) {
+
+      char ip[NI_MAXHOST]; // NOLINT This is a char array for interfacing with the C networking API
+      int status = getnameinfo(ifa->ifa_addr, sizeof(struct sockaddr_in), ip, NI_MAXHOST, nullptr, 0, NI_NUMERICHOST);
+      if (status != 0) {
+        continue;
+      }
+      output.push_back(std::string(ip));
+    }
+  }
+  freeifaddrs(ifaddr);
+
+  return output;
 }
 
 } // namespace dunedaq::utilities

--- a/src/ZmqUri.cpp
+++ b/src/ZmqUri.cpp
@@ -25,11 +25,37 @@ dunedaq::utilities::ZmqUri::ZmqUri(std::string connection_string)
   scheme = connection_string.substr(0, connection_string.find("://"));
   connection_string = connection_string.substr(connection_string.find("://") + 3);
 
+  if (connection_string.find(";") != std::string::npos) {
+    auto endpoint = connection_string.substr(0, connection_string.find(";"));
+    connection_string = connection_string.substr(connection_string.find(";") + 1);
+    if (endpoint.find(":") != std::string::npos) {
+      endpoint_port = endpoint.substr(endpoint.find(":") + 1);
+      endpoint_host = endpoint.substr(0, endpoint.find(":"));
+    } else {
+      endpoint_host = endpoint;
+    }
+  }
+
   if (connection_string.find(":") != std::string::npos) {
     port = connection_string.substr(connection_string.find(":") + 1);
     connection_string = connection_string.substr(0, connection_string.find(":"));
   }
   host = connection_string;
+}
+
+std::string
+dunedaq::utilities::ZmqUri::to_string()
+{
+  if (scheme == "tcp") {
+
+    std::string endpoint_str = "";
+    if (endpoint_host != "") {
+      endpoint_str = endpoint_host + ":" + (endpoint_port != "" ? endpoint_port : "*") + ";";
+    }
+    std::string host_str = host + ":" + (port != "" ? port : "*");
+    return scheme + "://" + endpoint_str + host_str;
+  }
+  return scheme + "://" + host;
 }
 
 std::vector<std::string>


### PR DESCRIPTION
# Description

See https://github.com/DUNE-DAQ/ipm/pull/119 for more details. Configuration objects and IP resolving utilities to allow `connect`ing from specific and multiple interfaces.


## Type of change

- [x] New feature or enhancement (non-breaking change which adds functionality)

## Testing checklist

- [x] Unit tests pass (e.g. `dbt-build --unittest`)
- [x] Minimal system quicktest passes (`pytest -s minimal_system_quick_test.py`)
- [x] Full set of integration tests pass (`dunedaq_integtest_bundle.sh`)
